### PR TITLE
v2.0.23

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
   - Skills: `src/skills/` (SKILL.md-based extensible workflows, e.g. DCF valuation)
   - Utils: `src/utils/` (env, config, caching, token estimation, markdown tables)
   - Evals: `src/evals/` (LangSmith evaluation runner with Ink UI)
-- Config: `.kalshi-deep-trading-bot/settings.json` (persisted model/provider selection)
+- Config: `.kalshi-trading-bot-cli/settings.json` (persisted model/provider selection)
 - Environment: `.env` (API keys; see `env.example`)
 - Scripts: `scripts/release.sh`
 
@@ -100,5 +100,5 @@
 ## Security
 
 - API keys stored in `.env` (gitignored). Users can also enter keys interactively via the CLI.
-- Config stored in `.kalshi-deep-trading-bot/settings.json` (gitignored).
+- Config stored in `.kalshi-trading-bot-cli/settings.json` (gitignored).
 - Never commit or expose real API keys, tokens, or credentials.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,13 @@
 ## Workflow
 
 - Always commit and push after each change.
+- When a command's flags or signature changes, update ALL of these:
+  - `src/commands/parse-args.ts` — flag parsing and `ParsedArgs` interface
+  - `src/commands/help.ts` — detailed help topic and overview section
+  - `src/commands/index.ts` — TUI slash command handler and `defaultArgs()`
+  - `src/commands/dispatch.ts` — CLI dispatch block
+  - `src/cli.ts` — autocomplete `slashCommands` array
+  - `src/components/intro.ts` — welcome screen command list
+  - `README.md` — commands table, flags table, and examples
+  - `src/__tests__/e2e.test.ts` — `makeParsedArgs()` defaults
+  - `src/gateway/commands/handler.ts` — `makeArgs()` defaults

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,4 +1,4 @@
-# Kalshi Deep Trading Bot — User Guide
+# Kalshi Trading Bot CLI — User Guide
 
 AI-powered prediction market terminal for [Kalshi](https://kalshi.com). Ask natural language questions, research markets, and trade — all from your terminal.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ bun start backtest --category crypto            # filter by category
 bun start backtest --export results.csv         # per-market detail
 ```
 
-```
+```text
 Octagon Backtest — 30-day lookback (03/15 – 04/14)
 ══════════════════════════════════════════════════════════
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Runs deep fundamental research on every market — independent probability estim
 
 Integrates with the [Octagon Research API](https://app.octagonai.co) for AI-generated probability estimates that power the edge detection engine.
 
-![Kalshi Deep Trading Bot](assets/screenshot.png)
+![Kalshi Trading Bot CLI](assets/screenshot.png)
 
 ## Quick Start
 
 ```bash
-git clone https://github.com/OctagonAI/kalshi-deep-trading-bot-cli.git
-cd kalshi-deep-trading-bot-cli
+git clone https://github.com/OctagonAI/kalshi-trading-bot-cli.git
+cd kalshi-trading-bot-cli
 bun install
 bun start
 ```
@@ -26,7 +26,7 @@ The setup wizard runs automatically on first launch — it walks you through API
 ```
 $ bun start
 
-Welcome to Kalshi Deep Trading Bot
+Welcome to Kalshi Trading Bot CLI
 Type help for commands, or just ask a question.
 
 > search crypto

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Type help for commands, or just ask a question.
 | `--days <n>` | Lookback period in days (backtest, default 30) |
 | `--resolved` | Resolved markets only (backtest) |
 | `--unresolved` | Open markets only (backtest) |
-| `--category <cat>` | Filter by category (backtest) |
+| `--category <cat>` | Filter by category (backtest, search edge) |
+| `--limit <n>` | Max results to show (search edge, default 20) |
 | `--export <path>` | Export per-market CSV (backtest) |
 
 ### Backtesting

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Type help for commands, or just ask a question.
 | Command | Description |
 |---------|-------------|
 | `search [theme\|ticker\|query]` | Find markets by keyword or theme |
+| `search edge [--min-edge N]` | Scan all markets by model edge |
 | `analyze <ticker>` | Deep analysis: edge, drivers, Kelly sizing |
 | `watch <ticker>` | Live price and orderbook feed |
 | `watch --theme <theme>` | Continuous theme scan |

--- a/README.md
+++ b/README.md
@@ -98,51 +98,50 @@ Type help for commands, or just ask a question.
 | `--min-edge <n>` | Minimum edge threshold |
 | `--interval <min>` | Scan interval in minutes (watch) |
 | `--live` | Force 15m scan interval (watch) |
+| `--days <n>` | Lookback period in days (backtest, default 30) |
 | `--resolved` | Resolved markets only (backtest) |
 | `--unresolved` | Open markets only (backtest) |
 | `--category <cat>` | Filter by category (backtest) |
-| `--from <date>` | Start date for date range (backtest) |
-| `--to <date>` | End date for date range (backtest) |
-| `--min-hours-before-close <n>` | Snapshot lead time in hours (backtest, default 24) |
-| `--snapshot last` | Use latest snapshot, no lead time (backtest) |
 | `--export <path>` | Export per-market CSV (backtest) |
 
 ### Backtesting
 
-Does the model find real edge? The `backtest` command answers this with two views:
+Does the model find real edge? Look back N days, compare what the model said then to where the market is now.
 
-- **Resolved** — measures model accuracy vs. market accuracy on settled markets using Brier scores, then checks if the edge signals paid off with flat-bet P&L.
-- **Unresolved** — shows where the model currently sees edge on open markets, ranked by size.
+- **Resolved** — scored against Kalshi settlement (YES=100%, NO=0%)
+- **Unresolved** — mark-to-market vs current Kalshi trading price
 
 ```bash
-bun start backtest                              # both views (default)
-bun start backtest --resolved                   # scorecard only
-bun start backtest --unresolved --min-edge 10   # live edge scanner (10pp threshold)
+bun start backtest                              # 30-day lookback (default)
+bun start backtest --days 60                    # 60-day lookback
+bun start backtest --resolved                   # resolved only
+bun start backtest --unresolved --min-edge 10   # unresolved, 10pp threshold
 bun start backtest --category crypto            # filter by category
-bun start backtest --from 2026-01-01 --to 2026-03-31
 bun start backtest --export results.csv         # per-market detail
 ```
 
 ```
-Octagon Backtest — 2025-01-01 – 2026-04-14
-═══════════════════════════════════════
+Octagon Backtest — 30-day lookback (03/15 – 04/14)
+══════════════════════════════════════════════════════════
 
-RESOLVED — Model Scorecard
-──────────────────────────
-VERDICT: Model shows edge (Skill +8.4% [CI: +0.7%, +15.7%]; ROI +13.8%)
+VERDICT: Model has edge (Skill +12.5% [CI: +4.1%, +20.8%]; ROI +7.8%)
 
-  Markets        1553  (82 events)
-  Brier (Octagon)   0.085
-  Brier (Market)    0.093
-  Skill Score       +8.4%  [95% CI: 0.7% to 15.7%]
-  Hit rate          68.2%   [95% CI: 63.2% to 73.2%]
-  Flat-bet P&L      +$46.85 (ROI: +13.8%)
+  Events         83
+  Markets        247   (142 resolved, 105 unresolved)
+  Brier (Octagon)   0.168
+  Brier (Market)    0.192
+  Skill Score       +12.5%  [95% CI: +4.1% to +20.8%]
+  Hit rate          61.4%  [95% CI: 54.2% to 68.1%]
+  Flat-bet P&L      +$14.38 (ROI: +7.8%)
 
-UNRESOLVED — Live Edge Scanner (min edge: 5pp)
-──────────────────────────────────────────────
-  Ticker                    Model   Market   Edge     Dir    Conf      Closes
-  KXIPODISCORD-26SEP01        88%       7%   +81pp   YES ▲   med     140 days
-  KXUSDBRLMAX-26DEC31-T5.7    82%       3%   +79pp   YES ▲   high    262 days
+RESOLVED (142 markets)
+  Ticker                    Model   Mkt Then   Outcome   Edge    P&L
+  KXBTC-26APR-B95000        72%     58%        YES 100%  +14pp   +$0.42
+  ...
+
+UNRESOLVED (105 markets)
+  Ticker                    Model   Mkt Then   Now       Edge    M2M
+  KXBTC-26MAY-B110000       71%     58%        68%       +13pp   +$0.10
   ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,16 @@ TELEMETRY_ENABLED=false bun start
 
 See the [User Guide](GUIDE.md) for detailed usage instructions, examples, and tips.
 
+## Star History
+
+<a href="https://www.star-history.com/?repos=OctagonAI%2Fkalshi-trading-bot-cli&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=OctagonAI/kalshi-trading-bot-cli&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=OctagonAI/kalshi-trading-bot-cli&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=OctagonAI/kalshi-trading-bot-cli&type=date&legend=top-left" />
+ </picture>
+</a>
+
 ## License
 
 MIT License — see [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Type help for commands, or just ask a question.
 | `buy <ticker> <count> [price] [yes\|no]` | Buy contracts |
 | `sell <ticker> <count> [price] [yes\|no]` | Sell contracts |
 | `cancel <order_id>` | Cancel a resting order |
+| `backtest` | Model accuracy scorecard + live edge scanner |
 | `portfolio` | Positions, P&L, risk snapshot |
 | `setup` | Re-run setup wizard (inside TUI) |
 | `init` | Launch setup wizard from CLI (`bun start init`) |
@@ -97,6 +98,53 @@ Type help for commands, or just ask a question.
 | `--min-edge <n>` | Minimum edge threshold |
 | `--interval <min>` | Scan interval in minutes (watch) |
 | `--live` | Force 15m scan interval (watch) |
+| `--resolved` | Resolved markets only (backtest) |
+| `--unresolved` | Open markets only (backtest) |
+| `--category <cat>` | Filter by category (backtest) |
+| `--from <date>` | Start date for date range (backtest) |
+| `--to <date>` | End date for date range (backtest) |
+| `--min-hours-before-close <n>` | Snapshot lead time in hours (backtest, default 24) |
+| `--snapshot last` | Use latest snapshot, no lead time (backtest) |
+| `--export <path>` | Export per-market CSV (backtest) |
+
+### Backtesting
+
+Does the model find real edge? The `backtest` command answers this with two views:
+
+- **Resolved** — measures model accuracy vs. market accuracy on settled markets using Brier scores, then checks if the edge signals paid off with flat-bet P&L.
+- **Unresolved** — shows where the model currently sees edge on open markets, ranked by size.
+
+```bash
+bun start backtest                              # both views (default)
+bun start backtest --resolved                   # scorecard only
+bun start backtest --unresolved --min-edge 10   # live edge scanner (10pp threshold)
+bun start backtest --category crypto            # filter by category
+bun start backtest --from 2026-01-01 --to 2026-03-31
+bun start backtest --export results.csv         # per-market detail
+```
+
+```
+Octagon Backtest — 2025-01-01 – 2026-04-14
+═══════════════════════════════════════
+
+RESOLVED — Model Scorecard
+──────────────────────────
+VERDICT: Model shows edge (Skill +8.4% [CI: +0.7%, +15.7%]; ROI +13.8%)
+
+  Markets        1553  (82 events)
+  Brier (Octagon)   0.085
+  Brier (Market)    0.093
+  Skill Score       +8.4%  [95% CI: 0.7% to 15.7%]
+  Hit rate          68.2%   [95% CI: 63.2% to 73.2%]
+  Flat-bet P&L      +$46.85 (ROI: +13.8%)
+
+UNRESOLVED — Live Edge Scanner (min edge: 5pp)
+──────────────────────────────────────────────
+  Ticker                    Model   Market   Edge     Dir    Conf      Closes
+  KXIPODISCORD-26SEP01        88%       7%   +81pp   YES ▲   med     140 days
+  KXUSDBRLMAX-26DEC31-T5.7    82%       3%   +79pp   YES ▲   high    262 days
+  ...
+```
 
 ### Demo Mode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "kalshi-deep-trading-bot",
+  "name": "kalshi-trading-bot-cli",
   "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kalshi-deep-trading-bot",
+      "name": "kalshi-trading-bot-cli",
       "version": "2.0.4",
       "dependencies": {
         "@langchain/anthropic": "^1.1.3",
@@ -22,7 +22,7 @@
         "zod": "^4.1.13"
       },
       "bin": {
-        "kalshi-deep-trading-bot": "src/index.tsx"
+        "kalshi-trading-bot-cli": "src/index.tsx"
       },
       "devDependencies": {
         "@babel/core": "^7.28.5",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "kalshi-deep-trading-bot",
+  "name": "kalshi-trading-bot-cli",
   "version": "2.0.23",
-  "description": "Kalshi Deep Trading Bot - AI-powered prediction market terminal.",
+  "description": "Kalshi Trading Bot CLI - AI-powered prediction market terminal.",
   "type": "module",
   "main": "src/index.tsx",
   "bin": {
-    "kalshi-deep-trading-bot": "./src/index.tsx"
+    "kalshi-trading-bot-cli": "./src/index.tsx"
   },
   "scripts": {
     "start": "bun run src/index.tsx",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "src/index.tsx",
   "bin": {
-    "kalshi-trading-bot-cli": "./src/index.tsx"
+    "kalshi-trading-bot-cli": "./src/index.tsx",
+    "kalshi-deep-trading-bot": "./src/index.tsx"
   },
   "scripts": {
     "start": "bun run src/index.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kalshi-trading-bot-cli",
-  "version": "2.0.23",
+  "version": "2.1.0",
   "description": "Kalshi Trading Bot CLI - AI-powered prediction market terminal.",
   "type": "module",
   "main": "src/index.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kalshi-deep-trading-bot",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Kalshi Deep Trading Bot - AI-powered prediction market terminal.",
   "type": "module",
   "main": "src/index.tsx",

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -54,6 +54,9 @@ function makeParsedArgs(overrides: Partial<ParsedArgs>): ParsedArgs {
     dryRun: false,
     verbose: false,
     performance: false,
+    resolved: false,
+    unresolved: false,
+    snapshotLast: false,
     parseErrors: [],
     ...overrides,
   };

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -56,7 +56,8 @@ function makeParsedArgs(overrides: Partial<ParsedArgs>): ParsedArgs {
     performance: false,
     resolved: false,
     unresolved: false,
-    snapshotLast: false,
+
+
     parseErrors: [],
     ...overrides,
   };

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -38,7 +38,7 @@ export interface GroupContext {
 // Default System Prompt (for backward compatibility)
 // ============================================================================
 
-export const DEFAULT_SYSTEM_PROMPT = `You are Kalshi Deep Trading Bot, a prediction market research and trading assistant.
+export const DEFAULT_SYSTEM_PROMPT = `You are Kalshi Trading Bot CLI, a prediction market research and trading assistant.
 
 Current date: ${getCurrentDate()}
 
@@ -95,7 +95,7 @@ export function buildSystemPrompt(model: string, channel?: string): string {
     ? `\n## Tables (for comparative/tabular data)\n\n${profile.tables}`
     : '';
 
-  return `You are Kalshi Deep Trading Bot, an AI-powered prediction market research and trading assistant.
+  return `You are Kalshi Trading Bot CLI, an AI-powered prediction market research and trading assistant.
 
 Current date: ${getCurrentDate()}
 

--- a/src/backtest/discovery.ts
+++ b/src/backtest/discovery.ts
@@ -93,12 +93,8 @@ export async function discoverSettledMarkets(
       : new Date(opts.to))
     : null;
 
-  const batchResults = await parallelMap(events, async ({ event_ticker, category: cat, me }) => {
-    // Skip mutually_exclusive events even if only one market is visible
-    if (me) return [];
+  const batchResults = await parallelMap(events, async ({ event_ticker, category: cat }) => {
     const markets = await fetchEventMarkets(event_ticker);
-    if (markets.length > 1) return [];
-
     const settled: SettledMarket[] = [];
 
     for (const m of markets) {
@@ -136,11 +132,8 @@ export async function discoverOpenMarkets(
   const { query: q2, params: p2 } = buildEventQuery('', opts?.category);
   const events2 = db.query(q2).all(p2) as Array<{ event_ticker: string; category: string | null; me: number }>;
 
-  const batchResults = await parallelMap(events2, async ({ event_ticker, category: cat, me }) => {
-    if (me) return [];
+  const batchResults = await parallelMap(events2, async ({ event_ticker, category: cat }) => {
     const markets = await fetchEventMarkets(event_ticker);
-    if (markets.length > 1) return [];
-
     const open: OpenMarket[] = [];
 
     for (const m of markets) {

--- a/src/backtest/discovery.ts
+++ b/src/backtest/discovery.ts
@@ -62,14 +62,12 @@ export async function discoverSettledMarkets(
   db: Database,
   opts?: { category?: string; from?: string; to?: string },
 ): Promise<SettledMarket[]> {
-  let query = `SELECT DISTINCT event_ticker,
-    (SELECT json_extract(drivers_json, '$[0].category') FROM octagon_reports r2
-     WHERE r2.event_ticker = r.event_ticker AND r2.variant_used = 'events-api' LIMIT 1) as category
+  let query = `SELECT DISTINCT event_ticker, series_category as category
     FROM octagon_reports r WHERE variant_used = 'events-api' AND has_history = 1`;
   const params: Record<string, string> = {};
   if (opts?.category) {
-    query += ' AND category LIKE $cat';
-    params.$cat = `%${opts.category}%`;
+    query += ' AND LOWER(series_category) LIKE $cat';
+    params.$cat = `%${opts.category.toLowerCase()}%`;
   }
 
   const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null }>;
@@ -78,8 +76,18 @@ export async function discoverSettledMarkets(
   const fromDate = opts?.from ? new Date(opts.from) : null;
   const toDate = opts?.to ? new Date(opts.to) : null;
 
+  // Look up which events are mutually_exclusive (multi-outcome bracket events)
+  const meRows = db.query(
+    "SELECT event_ticker, mutually_exclusive FROM octagon_reports WHERE variant_used = 'events-api'",
+  ).all() as Array<{ event_ticker: string; mutually_exclusive: number }>;
+  const meSet = new Set(meRows.filter(r => r.mutually_exclusive === 1).map(r => r.event_ticker));
+
   const batchResults = await parallelMap(events, async ({ event_ticker, category: cat }) => {
     const markets = await fetchEventMarkets(event_ticker);
+    // Skip multi-market events: event-level model_prob doesn't apply to individual brackets.
+    // This catches both mutually_exclusive (elections, sports) and bracket events (BTC daily).
+    if (markets.length > 1) return [];
+
     const settled: SettledMarket[] = [];
 
     for (const m of markets) {
@@ -116,21 +124,25 @@ export async function discoverOpenMarkets(
   db: Database,
   opts?: { category?: string },
 ): Promise<OpenMarket[]> {
-  let query = `SELECT DISTINCT event_ticker,
-    (SELECT json_extract(drivers_json, '$[0].category') FROM octagon_reports r2
-     WHERE r2.event_ticker = r.event_ticker AND r2.variant_used = 'events-api' LIMIT 1) as category
+  let query2 = `SELECT DISTINCT event_ticker, series_category as category, mutually_exclusive as me
     FROM octagon_reports r WHERE variant_used = 'events-api'`;
-  const params: Record<string, string> = {};
+  const params2: Record<string, string> = {};
   if (opts?.category) {
-    query += ' AND category LIKE $cat';
-    params.$cat = `%${opts.category}%`;
+    query2 += ' AND LOWER(series_category) LIKE $cat';
+    params2.$cat = `%${opts.category.toLowerCase()}%`;
   }
 
-  const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null }>;
-  logger.info(`[backtest] Checking ${events.length} events for open markets...`);
+  const events2 = db.query(query2).all(params2) as Array<{ event_ticker: string; category: string | null; me: number }>;
+  const meSet2 = new Set(events2.filter(r => r.me === 1).map(r => r.event_ticker));
+  logger.info(`[backtest] Checking ${events2.length} events for open markets...`);
 
-  const batchResults = await parallelMap(events, async ({ event_ticker, category: cat }) => {
+  const batchResults = await parallelMap(events2, async ({ event_ticker, category: cat }) => {
     const markets = await fetchEventMarkets(event_ticker);
+
+    // Skip multi-market events: event-level model_prob doesn't apply to individual brackets.
+    // This catches both mutually_exclusive (elections, sports) and bracket events (BTC daily).
+    if (markets.length > 1) return [];
+
     const open: OpenMarket[] = [];
 
     for (const m of markets) {

--- a/src/backtest/discovery.ts
+++ b/src/backtest/discovery.ts
@@ -1,7 +1,6 @@
 import type { Database } from 'bun:sqlite';
 import { callKalshiApi } from '../tools/kalshi/api.js';
 import type { KalshiMarket } from '../tools/kalshi/types.js';
-import { logger } from '../utils/logger.js';
 
 const CONCURRENCY = 10;
 
@@ -74,8 +73,6 @@ export async function discoverSettledMarkets(
   }
 
   const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null }>;
-  logger.info(`[backtest] Found ${events.length} events with Octagon history`);
-
   // Normalize date-only strings: fromDate → start of day, toDate → end of day
   const isDateOnly = /^\d{4}-\d{2}-\d{2}$/;
   const fromDate = opts?.from ? new Date(opts.from) : null;
@@ -84,12 +81,6 @@ export async function discoverSettledMarkets(
       ? new Date(opts.to + 'T23:59:59.999Z')
       : new Date(opts.to))
     : null;
-
-  // Look up which events are mutually_exclusive (multi-outcome bracket events)
-  const meRows = db.query(
-    "SELECT event_ticker, mutually_exclusive FROM octagon_reports WHERE variant_used = 'events-api'",
-  ).all() as Array<{ event_ticker: string; mutually_exclusive: number }>;
-  const meSet = new Set(meRows.filter(r => r.mutually_exclusive === 1).map(r => r.event_ticker));
 
   const batchResults = await parallelMap(events, async ({ event_ticker, category: cat }) => {
     const markets = await fetchEventMarkets(event_ticker);
@@ -121,9 +112,7 @@ export async function discoverSettledMarkets(
     return settled;
   }, CONCURRENCY);
 
-  const settled = batchResults.flat();
-  logger.info(`[backtest] Found ${settled.length} settled markets across ${events.length} events`);
-  return settled;
+  return batchResults.flat();
 }
 
 /**
@@ -133,7 +122,7 @@ export async function discoverOpenMarkets(
   db: Database,
   opts?: { category?: string },
 ): Promise<OpenMarket[]> {
-  let query2 = `SELECT DISTINCT event_ticker, series_category as category, mutually_exclusive as me
+  let query2 = `SELECT DISTINCT event_ticker, series_category as category
     FROM octagon_reports r WHERE variant_used = 'events-api'`;
   const params2: Record<string, string> = {};
   if (opts?.category) {
@@ -141,9 +130,7 @@ export async function discoverOpenMarkets(
     params2.$cat = `%${opts.category.toLowerCase()}%`;
   }
 
-  const events2 = db.query(query2).all(params2) as Array<{ event_ticker: string; category: string | null; me: number }>;
-  const meSet2 = new Set(events2.filter(r => r.me === 1).map(r => r.event_ticker));
-  logger.info(`[backtest] Checking ${events2.length} events for open markets...`);
+  const events2 = db.query(query2).all(params2) as Array<{ event_ticker: string; category: string | null }>;
 
   const batchResults = await parallelMap(events2, async ({ event_ticker, category: cat }) => {
     const markets = await fetchEventMarkets(event_ticker);
@@ -172,7 +159,5 @@ export async function discoverOpenMarkets(
     return open;
   }, CONCURRENCY);
 
-  const open = batchResults.flat();
-  logger.info(`[backtest] Found ${open.length} open markets with price data`);
-  return open;
+  return batchResults.flat();
 }

--- a/src/backtest/discovery.ts
+++ b/src/backtest/discovery.ts
@@ -23,7 +23,9 @@ export interface OpenMarket {
 
 /** Parse market price from Kalshi response (handles both cents and dollars formats). */
 function parsePrice(m: KalshiMarket): number {
-  return parseFloat(m.last_price_dollars ?? '') || (typeof m.last_price === 'number' ? m.last_price / 100 : 0);
+  const dollars = parseFloat(m.last_price_dollars ?? '');
+  if (Number.isFinite(dollars)) return dollars;
+  return typeof m.last_price === 'number' ? m.last_price / 100 : 0;
 }
 
 /** Fetch event markets from Kalshi, returning empty array on error. */
@@ -40,6 +42,22 @@ async function fetchEventMarkets(eventTicker: string): Promise<KalshiMarket[]> {
   } catch {
     return [];
   }
+}
+
+/** Build the event discovery query with optional category filter and extra WHERE clauses. */
+function buildEventQuery(
+  extraWhere: string,
+  category?: string,
+): { query: string; params: Record<string, string> } {
+  let query = `SELECT event_ticker, MAX(series_category) as category, MAX(mutually_exclusive) as me
+    FROM octagon_reports r WHERE variant_used = 'events-api'${extraWhere}`;
+  const params: Record<string, string> = {};
+  if (category) {
+    query += ' AND LOWER(series_category) LIKE $cat';
+    params.$cat = `%${category.toLowerCase()}%`;
+  }
+  query += ' GROUP BY event_ticker';
+  return { query, params };
 }
 
 /** Process items in parallel batches of `concurrency`. */
@@ -64,15 +82,7 @@ export async function discoverSettledMarkets(
   db: Database,
   opts?: { category?: string; from?: string; to?: string },
 ): Promise<SettledMarket[]> {
-  let query = `SELECT event_ticker, MAX(series_category) as category, MAX(mutually_exclusive) as me
-    FROM octagon_reports r WHERE variant_used = 'events-api' AND has_history = 1`;
-  const params: Record<string, string> = {};
-  if (opts?.category) {
-    query += ' AND LOWER(series_category) LIKE $cat';
-    params.$cat = `%${opts.category.toLowerCase()}%`;
-  }
-  query += ' GROUP BY event_ticker';
-
+  const { query, params } = buildEventQuery(' AND has_history = 1', opts?.category);
   const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null; me: number }>;
   // Normalize date-only strings: fromDate → start of day, toDate → end of day
   const isDateOnly = /^\d{4}-\d{2}-\d{2}$/;
@@ -123,16 +133,8 @@ export async function discoverOpenMarkets(
   db: Database,
   opts?: { category?: string },
 ): Promise<OpenMarket[]> {
-  let query2 = `SELECT event_ticker, MAX(series_category) as category, MAX(mutually_exclusive) as me
-    FROM octagon_reports r WHERE variant_used = 'events-api'`;
-  const params2: Record<string, string> = {};
-  if (opts?.category) {
-    query2 += ' AND LOWER(series_category) LIKE $cat';
-    params2.$cat = `%${opts.category.toLowerCase()}%`;
-  }
-  query2 += ' GROUP BY event_ticker';
-
-  const events2 = db.query(query2).all(params2) as Array<{ event_ticker: string; category: string | null; me: number }>;
+  const { query: q2, params: p2 } = buildEventQuery('', opts?.category);
+  const events2 = db.query(q2).all(p2) as Array<{ event_ticker: string; category: string | null; me: number }>;
 
   const batchResults = await parallelMap(events2, async ({ event_ticker, category: cat, me }) => {
     if (me) return [];

--- a/src/backtest/discovery.ts
+++ b/src/backtest/discovery.ts
@@ -1,0 +1,157 @@
+import type { Database } from 'bun:sqlite';
+import { callKalshiApi } from '../tools/kalshi/api.js';
+import type { KalshiMarket } from '../tools/kalshi/types.js';
+import { logger } from '../utils/logger.js';
+
+const CONCURRENCY = 10;
+
+export interface SettledMarket {
+  ticker: string;
+  event_ticker: string;
+  result: 'yes' | 'no';
+  close_time: string;
+  series_category: string;
+  last_price: number;         // last traded price (0-1)
+}
+
+export interface OpenMarket {
+  ticker: string;
+  event_ticker: string;
+  market_prob: number;        // current trading price (0-1)
+  close_time: string;
+  series_category: string;
+}
+
+/** Parse market price from Kalshi response (handles both cents and dollars formats). */
+function parsePrice(m: KalshiMarket): number {
+  return parseFloat(m.last_price_dollars ?? '') || (typeof m.last_price === 'number' ? m.last_price / 100 : 0);
+}
+
+/** Fetch event markets from Kalshi, returning empty array on error. */
+async function fetchEventMarkets(eventTicker: string): Promise<KalshiMarket[]> {
+  try {
+    const response = await callKalshiApi('GET', `/events/${eventTicker}`, {
+      params: { with_nested_markets: true },
+    });
+    const event = (response as any).event ?? response;
+    return ((event as any).markets ?? []) as KalshiMarket[];
+  } catch {
+    return [];
+  }
+}
+
+/** Process items in parallel batches of `concurrency`. */
+async function parallelMap<T, R>(
+  items: T[],
+  fn: (item: T) => Promise<R>,
+  concurrency: number,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += concurrency) {
+    const batch = items.slice(i, i + concurrency);
+    const batchResults = await Promise.all(batch.map(fn));
+    results.push(...batchResults);
+  }
+  return results;
+}
+
+/**
+ * Discover settled Kalshi markets that have Octagon coverage with history.
+ */
+export async function discoverSettledMarkets(
+  db: Database,
+  opts?: { category?: string; from?: string; to?: string },
+): Promise<SettledMarket[]> {
+  let query = `SELECT DISTINCT event_ticker,
+    (SELECT json_extract(drivers_json, '$[0].category') FROM octagon_reports r2
+     WHERE r2.event_ticker = r.event_ticker AND r2.variant_used = 'events-api' LIMIT 1) as category
+    FROM octagon_reports r WHERE variant_used = 'events-api' AND has_history = 1`;
+  const params: Record<string, string> = {};
+  if (opts?.category) {
+    query += ' AND category LIKE $cat';
+    params.$cat = `%${opts.category}%`;
+  }
+
+  const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null }>;
+  logger.info(`[backtest] Found ${events.length} events with Octagon history`);
+
+  const fromDate = opts?.from ? new Date(opts.from) : null;
+  const toDate = opts?.to ? new Date(opts.to) : null;
+
+  const batchResults = await parallelMap(events, async ({ event_ticker, category: cat }) => {
+    const markets = await fetchEventMarkets(event_ticker);
+    const settled: SettledMarket[] = [];
+
+    for (const m of markets) {
+      const result = (m.result ?? '').toLowerCase();
+      if (result !== 'yes' && result !== 'no') continue;
+
+      if (m.close_time) {
+        const closeDate = new Date(m.close_time);
+        if (fromDate && closeDate < fromDate) continue;
+        if (toDate && closeDate > toDate) continue;
+      }
+
+      settled.push({
+        ticker: m.ticker,
+        event_ticker,
+        result: result as 'yes' | 'no',
+        close_time: m.close_time ?? '',
+        series_category: cat ?? '',
+        last_price: parsePrice(m),
+      });
+    }
+    return settled;
+  }, CONCURRENCY);
+
+  const settled = batchResults.flat();
+  logger.info(`[backtest] Found ${settled.length} settled markets across ${events.length} events`);
+  return settled;
+}
+
+/**
+ * Discover open Kalshi markets that have Octagon coverage.
+ */
+export async function discoverOpenMarkets(
+  db: Database,
+  opts?: { category?: string },
+): Promise<OpenMarket[]> {
+  let query = `SELECT DISTINCT event_ticker,
+    (SELECT json_extract(drivers_json, '$[0].category') FROM octagon_reports r2
+     WHERE r2.event_ticker = r.event_ticker AND r2.variant_used = 'events-api' LIMIT 1) as category
+    FROM octagon_reports r WHERE variant_used = 'events-api'`;
+  const params: Record<string, string> = {};
+  if (opts?.category) {
+    query += ' AND category LIKE $cat';
+    params.$cat = `%${opts.category}%`;
+  }
+
+  const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null }>;
+  logger.info(`[backtest] Checking ${events.length} events for open markets...`);
+
+  const batchResults = await parallelMap(events, async ({ event_ticker, category: cat }) => {
+    const markets = await fetchEventMarkets(event_ticker);
+    const open: OpenMarket[] = [];
+
+    for (const m of markets) {
+      const status = (m.status ?? '').toLowerCase();
+      if (status !== 'open' && status !== 'active') continue;
+
+      const marketProb = parsePrice(m);
+      if (marketProb <= 0) continue;
+
+      open.push({
+        ticker: m.ticker,
+        event_ticker,
+        market_prob: marketProb,
+        close_time: m.close_time ?? '',
+        series_category: cat ?? '',
+      });
+    }
+    return open;
+  }, CONCURRENCY);
+
+  const open = batchResults.flat();
+  logger.info(`[backtest] Found ${open.length} open markets with price data`);
+  return open;
+}

--- a/src/backtest/discovery.ts
+++ b/src/backtest/discovery.ts
@@ -49,7 +49,7 @@ function buildEventQuery(
   extraWhere: string,
   category?: string,
 ): { query: string; params: Record<string, string> } {
-  let query = `SELECT event_ticker, MAX(series_category) as category, MAX(mutually_exclusive) as me
+  let query = `SELECT event_ticker, MAX(series_category) as category
     FROM octagon_reports r WHERE variant_used = 'events-api'${extraWhere}`;
   const params: Record<string, string> = {};
   if (category) {
@@ -83,7 +83,7 @@ export async function discoverSettledMarkets(
   opts?: { category?: string; from?: string; to?: string },
 ): Promise<SettledMarket[]> {
   const { query, params } = buildEventQuery(' AND has_history = 1', opts?.category);
-  const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null; me: number }>;
+  const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null }>;
   // Normalize date-only strings: fromDate → start of day, toDate → end of day
   const isDateOnly = /^\d{4}-\d{2}-\d{2}$/;
   const fromDate = opts?.from ? new Date(opts.from) : null;
@@ -130,7 +130,7 @@ export async function discoverOpenMarkets(
   opts?: { category?: string },
 ): Promise<OpenMarket[]> {
   const { query: q2, params: p2 } = buildEventQuery('', opts?.category);
-  const events2 = db.query(q2).all(p2) as Array<{ event_ticker: string; category: string | null; me: number }>;
+  const events2 = db.query(q2).all(p2) as Array<{ event_ticker: string; category: string | null }>;
 
   const batchResults = await parallelMap(events2, async ({ event_ticker, category: cat }) => {
     const markets = await fetchEventMarkets(event_ticker);

--- a/src/backtest/discovery.ts
+++ b/src/backtest/discovery.ts
@@ -64,13 +64,14 @@ export async function discoverSettledMarkets(
   db: Database,
   opts?: { category?: string; from?: string; to?: string },
 ): Promise<SettledMarket[]> {
-  let query = `SELECT DISTINCT event_ticker, series_category as category, mutually_exclusive as me
+  let query = `SELECT event_ticker, MAX(series_category) as category, MAX(mutually_exclusive) as me
     FROM octagon_reports r WHERE variant_used = 'events-api' AND has_history = 1`;
   const params: Record<string, string> = {};
   if (opts?.category) {
     query += ' AND LOWER(series_category) LIKE $cat';
     params.$cat = `%${opts.category.toLowerCase()}%`;
   }
+  query += ' GROUP BY event_ticker';
 
   const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null; me: number }>;
   // Normalize date-only strings: fromDate → start of day, toDate → end of day
@@ -122,13 +123,14 @@ export async function discoverOpenMarkets(
   db: Database,
   opts?: { category?: string },
 ): Promise<OpenMarket[]> {
-  let query2 = `SELECT DISTINCT event_ticker, series_category as category, mutually_exclusive as me
+  let query2 = `SELECT event_ticker, MAX(series_category) as category, MAX(mutually_exclusive) as me
     FROM octagon_reports r WHERE variant_used = 'events-api'`;
   const params2: Record<string, string> = {};
   if (opts?.category) {
     query2 += ' AND LOWER(series_category) LIKE $cat';
     params2.$cat = `%${opts.category.toLowerCase()}%`;
   }
+  query2 += ' GROUP BY event_ticker';
 
   const events2 = db.query(query2).all(params2) as Array<{ event_ticker: string; category: string | null; me: number }>;
 

--- a/src/backtest/discovery.ts
+++ b/src/backtest/discovery.ts
@@ -64,7 +64,7 @@ export async function discoverSettledMarkets(
   db: Database,
   opts?: { category?: string; from?: string; to?: string },
 ): Promise<SettledMarket[]> {
-  let query = `SELECT DISTINCT event_ticker, series_category as category
+  let query = `SELECT DISTINCT event_ticker, series_category as category, mutually_exclusive as me
     FROM octagon_reports r WHERE variant_used = 'events-api' AND has_history = 1`;
   const params: Record<string, string> = {};
   if (opts?.category) {
@@ -72,7 +72,7 @@ export async function discoverSettledMarkets(
     params.$cat = `%${opts.category.toLowerCase()}%`;
   }
 
-  const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null }>;
+  const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null; me: number }>;
   // Normalize date-only strings: fromDate → start of day, toDate → end of day
   const isDateOnly = /^\d{4}-\d{2}-\d{2}$/;
   const fromDate = opts?.from ? new Date(opts.from) : null;
@@ -82,10 +82,10 @@ export async function discoverSettledMarkets(
       : new Date(opts.to))
     : null;
 
-  const batchResults = await parallelMap(events, async ({ event_ticker, category: cat }) => {
+  const batchResults = await parallelMap(events, async ({ event_ticker, category: cat, me }) => {
+    // Skip mutually_exclusive events even if only one market is visible
+    if (me) return [];
     const markets = await fetchEventMarkets(event_ticker);
-    // Skip multi-market events: event-level model_prob doesn't apply to individual brackets.
-    // This catches both mutually_exclusive (elections, sports) and bracket events (BTC daily).
     if (markets.length > 1) return [];
 
     const settled: SettledMarket[] = [];
@@ -122,7 +122,7 @@ export async function discoverOpenMarkets(
   db: Database,
   opts?: { category?: string },
 ): Promise<OpenMarket[]> {
-  let query2 = `SELECT DISTINCT event_ticker, series_category as category
+  let query2 = `SELECT DISTINCT event_ticker, series_category as category, mutually_exclusive as me
     FROM octagon_reports r WHERE variant_used = 'events-api'`;
   const params2: Record<string, string> = {};
   if (opts?.category) {
@@ -130,13 +130,11 @@ export async function discoverOpenMarkets(
     params2.$cat = `%${opts.category.toLowerCase()}%`;
   }
 
-  const events2 = db.query(query2).all(params2) as Array<{ event_ticker: string; category: string | null }>;
+  const events2 = db.query(query2).all(params2) as Array<{ event_ticker: string; category: string | null; me: number }>;
 
-  const batchResults = await parallelMap(events2, async ({ event_ticker, category: cat }) => {
+  const batchResults = await parallelMap(events2, async ({ event_ticker, category: cat, me }) => {
+    if (me) return [];
     const markets = await fetchEventMarkets(event_ticker);
-
-    // Skip multi-market events: event-level model_prob doesn't apply to individual brackets.
-    // This catches both mutually_exclusive (elections, sports) and bracket events (BTC daily).
     if (markets.length > 1) return [];
 
     const open: OpenMarket[] = [];

--- a/src/backtest/discovery.ts
+++ b/src/backtest/discovery.ts
@@ -33,8 +33,11 @@ async function fetchEventMarkets(eventTicker: string): Promise<KalshiMarket[]> {
     const response = await callKalshiApi('GET', `/events/${eventTicker}`, {
       params: { with_nested_markets: true },
     });
-    const event = (response as any).event ?? response;
-    return ((event as any).markets ?? []) as KalshiMarket[];
+    if (!response || typeof response !== 'object') return [];
+    const obj = response as Record<string, unknown>;
+    const event = (obj.event ?? obj) as Record<string, unknown>;
+    const markets = event.markets;
+    return Array.isArray(markets) ? markets as KalshiMarket[] : [];
   } catch {
     return [];
   }
@@ -73,8 +76,14 @@ export async function discoverSettledMarkets(
   const events = db.query(query).all(params) as Array<{ event_ticker: string; category: string | null }>;
   logger.info(`[backtest] Found ${events.length} events with Octagon history`);
 
+  // Normalize date-only strings: fromDate → start of day, toDate → end of day
+  const isDateOnly = /^\d{4}-\d{2}-\d{2}$/;
   const fromDate = opts?.from ? new Date(opts.from) : null;
-  const toDate = opts?.to ? new Date(opts.to) : null;
+  const toDate = opts?.to
+    ? (isDateOnly.test(opts.to)
+      ? new Date(opts.to + 'T23:59:59.999Z')
+      : new Date(opts.to))
+    : null;
 
   // Look up which events are mutually_exclusive (multi-outcome bracket events)
   const meRows = db.query(

--- a/src/backtest/fetcher.ts
+++ b/src/backtest/fetcher.ts
@@ -5,13 +5,13 @@ export interface HistorySnapshot {
   history_id: number;
   event_ticker: string;
   captured_at: string;
-  name: string;
-  series_category: string;
-  confidence_score: number;
+  name: string | null;
+  series_category: string | null;
+  confidence_score: number | null;
   model_probability: number;   // percentage 0-100
   market_probability: number;  // percentage 0-100
-  edge_pp: number;
-  close_time: string;
+  edge_pp: number | null;
+  close_time: string | null;
 }
 
 interface HistoryPage {

--- a/src/backtest/fetcher.ts
+++ b/src/backtest/fetcher.ts
@@ -87,9 +87,20 @@ export async function fetchEventHistory(
       throw new Error(`Octagon history API ${resp.status} for ${eventTicker}: ${body.slice(0, 200)}`);
     }
 
-    const page = (await resp.json()) as HistoryPage;
-    all.push(...page.data);
-    cursor = page.has_more ? page.next_cursor : null;
+    const raw = (await resp.json()) as unknown;
+    if (!raw || typeof raw !== 'object') {
+      throw new Error(`Octagon history API returned invalid response for ${eventTicker}`);
+    }
+    const page = raw as Record<string, unknown>;
+    if (!Array.isArray(page.data)) {
+      throw new Error(`Octagon history API response missing data array for ${eventTicker}`);
+    }
+    const hasMore = typeof page.has_more === 'boolean' ? page.has_more : false;
+    if (hasMore && !page.next_cursor) {
+      throw new Error(`Octagon history API has_more=true but next_cursor missing for ${eventTicker}`);
+    }
+    all.push(...(page.data as HistorySnapshot[]));
+    cursor = hasMore ? (page.next_cursor as string) : null;
   } while (cursor);
 
   return all;

--- a/src/backtest/fetcher.ts
+++ b/src/backtest/fetcher.ts
@@ -1,6 +1,13 @@
 import type { Database } from 'bun:sqlite';
 
 /** Narrow snapshot type representing what we actually store and use from history. */
+export interface OutcomeProbability {
+  market_ticker: string;
+  outcome_name?: string;
+  model_probability: number;   // percentage 0-100
+  market_probability: number;  // percentage 0-100
+}
+
 export interface HistorySnapshot {
   history_id: number;
   event_ticker: string;
@@ -12,6 +19,8 @@ export interface HistorySnapshot {
   market_probability: number;  // percentage 0-100
   edge_pp: number | null;
   close_time: string | null;
+  outcome_probabilities?: OutcomeProbability[] | null;
+  outcome_probabilities_json?: string | null; // raw JSON from DB cache
 }
 
 interface HistoryPage {
@@ -92,9 +101,16 @@ export async function fetchAndCacheHistory(
     if (cached.cnt > 0) {
       const rows = db.query(
         `SELECT history_id, event_ticker, captured_at, name, series_category,
-                confidence_score, model_probability, market_probability, edge_pp, close_time
+                confidence_score, model_probability, market_probability, edge_pp, close_time,
+                outcome_probabilities_json
          FROM octagon_history WHERE event_ticker = $et ORDER BY captured_at ASC`,
       ).all({ $et: eventTicker }) as HistorySnapshot[];
+      // Parse outcome_probabilities from cached JSON
+      for (const r of rows) {
+        if (r.outcome_probabilities_json) {
+          try { r.outcome_probabilities = JSON.parse(r.outcome_probabilities_json); } catch { /* skip */ }
+        }
+      }
       return rows;
     }
   }
@@ -107,9 +123,9 @@ export async function fetchAndCacheHistory(
     const insert = db.prepare(`
       INSERT OR IGNORE INTO octagon_history
         (history_id, event_ticker, captured_at, model_probability, market_probability,
-         edge_pp, confidence_score, series_category, close_time, name)
+         edge_pp, confidence_score, series_category, close_time, name, outcome_probabilities_json)
       VALUES ($history_id, $event_ticker, $captured_at, $model_probability, $market_probability,
-              $edge_pp, $confidence_score, $series_category, $close_time, $name)
+              $edge_pp, $confidence_score, $series_category, $close_time, $name, $opj)
     `);
 
     db.transaction(() => {
@@ -125,6 +141,7 @@ export async function fetchAndCacheHistory(
           $series_category: s.series_category ?? null,
           $close_time: s.close_time ?? null,
           $name: s.name ?? null,
+          $opj: s.outcome_probabilities ? JSON.stringify(s.outcome_probabilities) : null,
         });
       }
     })();

--- a/src/backtest/fetcher.ts
+++ b/src/backtest/fetcher.ts
@@ -1,10 +1,22 @@
 import type { Database } from 'bun:sqlite';
-import type { OctagonEventEntry } from '../scan/octagon-events-api.js';
-import { logger } from '../utils/logger.js';
+
+/** Narrow snapshot type representing what we actually store and use from history. */
+export interface HistorySnapshot {
+  history_id: number;
+  event_ticker: string;
+  captured_at: string;
+  name: string;
+  series_category: string;
+  confidence_score: number;
+  model_probability: number;   // percentage 0-100
+  market_probability: number;  // percentage 0-100
+  edge_pp: number;
+  close_time: string;
+}
 
 interface HistoryPage {
   event_ticker: string;
-  data: OctagonEventEntry[];
+  data: HistorySnapshot[];
   next_cursor: string | null;
   has_more: boolean;
 }
@@ -20,11 +32,11 @@ const TIMEOUT_MS = 60_000;
 export async function fetchEventHistory(
   eventTicker: string,
   opts?: { capturedFrom?: string; capturedTo?: string },
-): Promise<OctagonEventEntry[]> {
+): Promise<HistorySnapshot[]> {
   const apiKey = process.env.OCTAGON_API_KEY;
   if (!apiKey) throw new Error('OCTAGON_API_KEY not set');
 
-  const all: OctagonEventEntry[] = [];
+  const all: HistorySnapshot[] = [];
   let cursor: string | null = null;
 
   do {
@@ -61,89 +73,63 @@ export async function fetchEventHistory(
 
 /**
  * Fetch event history and cache it in the local octagon_history table.
- * Returns cached data if already present and not expired.
+ * Only uses the cache for full-history requests (no time window).
+ * When capturedFrom/capturedTo are provided, always fetches fresh from the API.
  */
 export async function fetchAndCacheHistory(
   db: Database,
   eventTicker: string,
   opts?: { capturedFrom?: string; capturedTo?: string },
-): Promise<OctagonEventEntry[]> {
-  // Check if we already have cached history for this event
-  const cached = db.query(
-    'SELECT COUNT(*) as cnt FROM octagon_history WHERE event_ticker = $et',
-  ).get({ $et: eventTicker }) as { cnt: number };
+): Promise<HistorySnapshot[]> {
+  const hasWindow = !!(opts?.capturedFrom || opts?.capturedTo);
 
-  if (cached.cnt > 0) {
-    // Return from cache
-    const rows = db.query(
-      `SELECT * FROM octagon_history WHERE event_ticker = $et ORDER BY captured_at ASC`,
-    ).all({ $et: eventTicker }) as Array<{
-      history_id: number;
-      event_ticker: string;
-      captured_at: string;
-      model_probability: number;
-      market_probability: number;
-      edge_pp: number;
-      confidence_score: number;
-      series_category: string;
-      close_time: string;
-      name: string;
-    }>;
-    // Convert DB rows back to OctagonEventEntry shape (minimal fields needed)
-    return rows.map(r => ({
-      history_id: r.history_id,
-      run_id: '',
-      captured_at: r.captured_at,
-      event_ticker: r.event_ticker,
-      name: r.name ?? '',
-      slug: '',
-      series_category: r.series_category ?? '',
-      available_on_brokers: true,
-      mutually_exclusive: false,
-      analysis_last_updated: r.captured_at,
-      confidence_score: r.confidence_score,
-      model_probability: r.model_probability,
-      market_probability: r.market_probability,
-      edge_pp: r.edge_pp ?? 0,
-      expected_return: 0,
-      r_score: 0,
-      total_volume: 0,
-      total_open_interest: 0,
-      close_time: r.close_time ?? '',
-      key_takeaway: '',
-    }));
+  // Only use cache for full-history requests (no time window filter)
+  if (!hasWindow) {
+    const cached = db.query(
+      'SELECT COUNT(*) as cnt FROM octagon_history WHERE event_ticker = $et',
+    ).get({ $et: eventTicker }) as { cnt: number };
+
+    if (cached.cnt > 0) {
+      const rows = db.query(
+        `SELECT history_id, event_ticker, captured_at, name, series_category,
+                confidence_score, model_probability, market_probability, edge_pp, close_time
+         FROM octagon_history WHERE event_ticker = $et ORDER BY captured_at ASC`,
+      ).all({ $et: eventTicker }) as HistorySnapshot[];
+      return rows;
+    }
   }
 
   // Fetch from API
   const snapshots = await fetchEventHistory(eventTicker, opts);
 
-  // Cache in DB
-  const insert = db.prepare(`
-    INSERT OR IGNORE INTO octagon_history
-      (history_id, event_ticker, captured_at, model_probability, market_probability,
-       edge_pp, confidence_score, series_category, close_time, name)
-    VALUES ($history_id, $event_ticker, $captured_at, $model_probability, $market_probability,
-            $edge_pp, $confidence_score, $series_category, $close_time, $name)
-  `);
+  // Cache in DB (only for full-history requests to avoid partial cache)
+  if (!hasWindow) {
+    const insert = db.prepare(`
+      INSERT OR IGNORE INTO octagon_history
+        (history_id, event_ticker, captured_at, model_probability, market_probability,
+         edge_pp, confidence_score, series_category, close_time, name)
+      VALUES ($history_id, $event_ticker, $captured_at, $model_probability, $market_probability,
+              $edge_pp, $confidence_score, $series_category, $close_time, $name)
+    `);
 
-  db.transaction(() => {
-    for (const s of snapshots) {
-      insert.run({
-        $history_id: s.history_id,
-        $event_ticker: s.event_ticker,
-        $captured_at: s.captured_at,
-        $model_probability: s.model_probability,
-        $market_probability: s.market_probability,
-        $edge_pp: s.edge_pp,
-        $confidence_score: s.confidence_score,
-        $series_category: s.series_category ?? '',
-        $close_time: s.close_time ?? '',
-        $name: s.name ?? '',
-      });
-    }
-  })();
+    db.transaction(() => {
+      for (const s of snapshots) {
+        insert.run({
+          $history_id: s.history_id,
+          $event_ticker: s.event_ticker,
+          $captured_at: s.captured_at,
+          $model_probability: s.model_probability,
+          $market_probability: s.market_probability,
+          $edge_pp: s.edge_pp,
+          $confidence_score: s.confidence_score,
+          $series_category: s.series_category ?? '',
+          $close_time: s.close_time ?? '',
+          $name: s.name ?? '',
+        });
+      }
+    })();
+  }
 
-  logger.info(`[backtest] Cached ${snapshots.length} history snapshots for ${eventTicker}`);
   return snapshots;
 }
 
@@ -153,15 +139,14 @@ export async function fetchAndCacheHistory(
  * Probabilities in the returned snapshot are percentages (0-100).
  */
 export function selectSnapshot(
-  snapshots: OctagonEventEntry[],
+  snapshots: HistorySnapshot[],
   closeTime: string,
   minHoursBeforeClose: number,
-): OctagonEventEntry | null {
+): HistorySnapshot | null {
   const closeEpoch = new Date(closeTime).getTime();
   const cutoff = closeEpoch - minHoursBeforeClose * 3600 * 1000;
 
-  // Find the last snapshot before the cutoff
-  let best: OctagonEventEntry | null = null;
+  let best: HistorySnapshot | null = null;
   for (const s of snapshots) {
     const capturedEpoch = new Date(s.captured_at).getTime();
     if (capturedEpoch <= cutoff) {

--- a/src/backtest/fetcher.ts
+++ b/src/backtest/fetcher.ts
@@ -1,5 +1,13 @@
 import type { Database } from 'bun:sqlite';
 
+/** Thrown when the history API requires a paid subscription. */
+export class SubscriptionRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SubscriptionRequiredError';
+  }
+}
+
 /** Narrow snapshot type representing what we actually store and use from history. */
 export interface OutcomeProbability {
   market_ticker: string;
@@ -69,6 +77,13 @@ export async function fetchEventHistory(
 
     if (!resp.ok) {
       const body = await resp.text().catch(() => '');
+      if (resp.status === 403 || resp.status === 402) {
+        throw new SubscriptionRequiredError(
+          'The Octagon history API requires a paid subscription. ' +
+          'The unresolved edge scanner (--unresolved) uses the free events API. ' +
+          'Upgrade at https://app.octagonai.co to unlock resolved market backtesting.',
+        );
+      }
       throw new Error(`Octagon history API ${resp.status} for ${eventTicker}: ${body.slice(0, 200)}`);
     }
 

--- a/src/backtest/fetcher.ts
+++ b/src/backtest/fetcher.ts
@@ -1,0 +1,174 @@
+import type { Database } from 'bun:sqlite';
+import type { OctagonEventEntry } from '../scan/octagon-events-api.js';
+import { logger } from '../utils/logger.js';
+
+interface HistoryPage {
+  event_ticker: string;
+  data: OctagonEventEntry[];
+  next_cursor: string | null;
+  has_more: boolean;
+}
+
+const EVENTS_API_BASE = 'https://api.octagonai.co/v1';
+const PAGE_LIMIT = 200;
+const TIMEOUT_MS = 60_000;
+
+/**
+ * Fetch all history snapshots for an event from the Octagon API.
+ * Supports optional time window filtering via captured_from/captured_to.
+ */
+export async function fetchEventHistory(
+  eventTicker: string,
+  opts?: { capturedFrom?: string; capturedTo?: string },
+): Promise<OctagonEventEntry[]> {
+  const apiKey = process.env.OCTAGON_API_KEY;
+  if (!apiKey) throw new Error('OCTAGON_API_KEY not set');
+
+  const all: OctagonEventEntry[] = [];
+  let cursor: string | null = null;
+
+  do {
+    const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+    if (cursor) params.set('cursor', cursor);
+    if (opts?.capturedFrom) params.set('captured_from', opts.capturedFrom);
+    if (opts?.capturedTo) params.set('captured_to', opts.capturedTo);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    let resp: Response;
+    try {
+      resp = await fetch(
+        `${EVENTS_API_BASE}/prediction-markets/events/${encodeURIComponent(eventTicker)}/history?${params}`,
+        { headers: { Authorization: `Bearer ${apiKey}` }, signal: controller.signal },
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '');
+      throw new Error(`Octagon history API ${resp.status} for ${eventTicker}: ${body.slice(0, 200)}`);
+    }
+
+    const page = (await resp.json()) as HistoryPage;
+    all.push(...page.data);
+    cursor = page.has_more ? page.next_cursor : null;
+  } while (cursor);
+
+  return all;
+}
+
+/**
+ * Fetch event history and cache it in the local octagon_history table.
+ * Returns cached data if already present and not expired.
+ */
+export async function fetchAndCacheHistory(
+  db: Database,
+  eventTicker: string,
+  opts?: { capturedFrom?: string; capturedTo?: string },
+): Promise<OctagonEventEntry[]> {
+  // Check if we already have cached history for this event
+  const cached = db.query(
+    'SELECT COUNT(*) as cnt FROM octagon_history WHERE event_ticker = $et',
+  ).get({ $et: eventTicker }) as { cnt: number };
+
+  if (cached.cnt > 0) {
+    // Return from cache
+    const rows = db.query(
+      `SELECT * FROM octagon_history WHERE event_ticker = $et ORDER BY captured_at ASC`,
+    ).all({ $et: eventTicker }) as Array<{
+      history_id: number;
+      event_ticker: string;
+      captured_at: string;
+      model_probability: number;
+      market_probability: number;
+      edge_pp: number;
+      confidence_score: number;
+      series_category: string;
+      close_time: string;
+      name: string;
+    }>;
+    // Convert DB rows back to OctagonEventEntry shape (minimal fields needed)
+    return rows.map(r => ({
+      history_id: r.history_id,
+      run_id: '',
+      captured_at: r.captured_at,
+      event_ticker: r.event_ticker,
+      name: r.name ?? '',
+      slug: '',
+      series_category: r.series_category ?? '',
+      available_on_brokers: true,
+      mutually_exclusive: false,
+      analysis_last_updated: r.captured_at,
+      confidence_score: r.confidence_score,
+      model_probability: r.model_probability,
+      market_probability: r.market_probability,
+      edge_pp: r.edge_pp ?? 0,
+      expected_return: 0,
+      r_score: 0,
+      total_volume: 0,
+      total_open_interest: 0,
+      close_time: r.close_time ?? '',
+      key_takeaway: '',
+    }));
+  }
+
+  // Fetch from API
+  const snapshots = await fetchEventHistory(eventTicker, opts);
+
+  // Cache in DB
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO octagon_history
+      (history_id, event_ticker, captured_at, model_probability, market_probability,
+       edge_pp, confidence_score, series_category, close_time, name)
+    VALUES ($history_id, $event_ticker, $captured_at, $model_probability, $market_probability,
+            $edge_pp, $confidence_score, $series_category, $close_time, $name)
+  `);
+
+  db.transaction(() => {
+    for (const s of snapshots) {
+      insert.run({
+        $history_id: s.history_id,
+        $event_ticker: s.event_ticker,
+        $captured_at: s.captured_at,
+        $model_probability: s.model_probability,
+        $market_probability: s.market_probability,
+        $edge_pp: s.edge_pp,
+        $confidence_score: s.confidence_score,
+        $series_category: s.series_category ?? '',
+        $close_time: s.close_time ?? '',
+        $name: s.name ?? '',
+      });
+    }
+  })();
+
+  logger.info(`[backtest] Cached ${snapshots.length} history snapshots for ${eventTicker}`);
+  return snapshots;
+}
+
+/**
+ * Select the appropriate snapshot for backtesting a resolved market.
+ * Returns the last snapshot captured >= minHours before market close.
+ * Probabilities in the returned snapshot are percentages (0-100).
+ */
+export function selectSnapshot(
+  snapshots: OctagonEventEntry[],
+  closeTime: string,
+  minHoursBeforeClose: number,
+): OctagonEventEntry | null {
+  const closeEpoch = new Date(closeTime).getTime();
+  const cutoff = closeEpoch - minHoursBeforeClose * 3600 * 1000;
+
+  // Find the last snapshot before the cutoff
+  let best: OctagonEventEntry | null = null;
+  for (const s of snapshots) {
+    const capturedEpoch = new Date(s.captured_at).getTime();
+    if (capturedEpoch <= cutoff) {
+      if (!best || capturedEpoch > new Date(best.captured_at).getTime()) {
+        best = s;
+      }
+    }
+  }
+  return best;
+}

--- a/src/backtest/fetcher.ts
+++ b/src/backtest/fetcher.ts
@@ -166,25 +166,23 @@ export async function fetchAndCacheHistory(
 }
 
 /**
- * Select the appropriate snapshot for backtesting a resolved market.
- * Returns the last snapshot captured >= minHours before market close.
+ * Select the snapshot closest to a target date (N days ago).
+ * Returns the last snapshot captured on or before the target date.
  * Probabilities in the returned snapshot are percentages (0-100).
  */
-export function selectSnapshot(
+export function selectSnapshotByDate(
   snapshots: HistorySnapshot[],
-  closeTime: string,
-  minHoursBeforeClose: number,
+  targetDate: Date,
 ): HistorySnapshot | null {
-  const closeEpoch = new Date(closeTime).getTime();
-  const cutoff = closeEpoch - minHoursBeforeClose * 3600 * 1000;
+  const targetEpoch = targetDate.getTime();
 
   let best: HistorySnapshot | null = null;
+  let bestEpoch = -Infinity;
   for (const s of snapshots) {
     const capturedEpoch = new Date(s.captured_at).getTime();
-    if (capturedEpoch <= cutoff) {
-      if (!best || capturedEpoch > new Date(best.captured_at).getTime()) {
-        best = s;
-      }
+    if (capturedEpoch <= targetEpoch && capturedEpoch > bestEpoch) {
+      best = s;
+      bestEpoch = capturedEpoch;
     }
   }
   return best;

--- a/src/backtest/fetcher.ts
+++ b/src/backtest/fetcher.ts
@@ -122,9 +122,9 @@ export async function fetchAndCacheHistory(
           $market_probability: s.market_probability,
           $edge_pp: s.edge_pp,
           $confidence_score: s.confidence_score,
-          $series_category: s.series_category ?? '',
-          $close_time: s.close_time ?? '',
-          $name: s.name ?? '',
+          $series_category: s.series_category ?? null,
+          $close_time: s.close_time ?? null,
+          $name: s.name ?? null,
         });
       }
     })();

--- a/src/backtest/metrics.ts
+++ b/src/backtest/metrics.ts
@@ -1,0 +1,148 @@
+import { computeBrier } from '../eval/brier.js';
+import type { ResolvedMarket, ResolvedResult } from './types.js';
+
+/**
+ * Skill score: how much better Octagon is vs the market as a forecaster.
+ * Positive = model beats market. Negative = market is better.
+ */
+export function computeSkillScore(brierOctagon: number, brierMarket: number): number {
+  if (brierMarket === 0) return 0;
+  return 1 - (brierOctagon / brierMarket);
+}
+
+/**
+ * Bootstrap confidence interval for a statistic.
+ * Resamples `data` with replacement `iterations` times, computes `statFn` on each sample.
+ * Returns [lower, upper] at the given confidence level (default 95%).
+ */
+export function bootstrapCI(
+  data: number[],
+  statFn: (sample: number[]) => number,
+  iterations = 10_000,
+  alpha = 0.05,
+): [number, number] {
+  if (data.length === 0) return [0, 0];
+
+  const stats: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const sample: number[] = [];
+    for (let j = 0; j < data.length; j++) {
+      sample.push(data[Math.floor(Math.random() * data.length)]);
+    }
+    stats.push(statFn(sample));
+  }
+  stats.sort((a, b) => a - b);
+
+  const lo = Math.floor((alpha / 2) * stats.length);
+  const hi = Math.floor((1 - alpha / 2) * stats.length);
+  return [stats[lo], stats[hi]];
+}
+
+/**
+ * Compute all resolved-market metrics from a list of resolved markets.
+ * Each market must have model_prob, market_prob, outcome, edge_pp.
+ */
+export function computeResolvedMetrics(markets: ResolvedMarket[], minEdgePp = 5): ResolvedResult {
+  const n = markets.length;
+  if (n === 0) {
+    return {
+      verdict: { summary: 'No resolved markets with Octagon coverage found.', significant: false, profitable: false },
+      brier_octagon: 0,
+      brier_market: 0,
+      skill_score: 0,
+      skill_ci: [0, 0],
+      edge_signals: 0,
+      edge_hit_rate: 0,
+      hit_rate_ci: [0, 0],
+      flat_bet_pnl: 0,
+      flat_bet_roi: 0,
+      markets_evaluated: 0,
+      events_evaluated: 0,
+      coverage: 0,
+      markets: [],
+    };
+  }
+
+  // Brier scores
+  const brierOctagonScores = markets.map(m => computeBrier(m.model_prob, m.outcome));
+  const brierMarketScores = markets.map(m => computeBrier(m.market_prob, m.outcome));
+  const brierOctagon = brierOctagonScores.reduce((a, b) => a + b, 0) / n;
+  const brierMarket = brierMarketScores.reduce((a, b) => a + b, 0) / n;
+
+  // Skill score with bootstrap CI
+  const skillScore = computeSkillScore(brierOctagon, brierMarket);
+
+  // Bootstrap skill: resample paired (octagon_brier, market_brier), compute skill on each
+  const pairedDiffs = markets.map((_, i) => brierMarketScores[i] - brierOctagonScores[i]);
+  const skillCI = bootstrapCI(pairedDiffs, (sample) => {
+    const avgDiff = sample.reduce((a, b) => a + b, 0) / sample.length;
+    const avgMarket = brierMarket; // approximate
+    return avgMarket === 0 ? 0 : avgDiff / avgMarket;
+  });
+
+  // Edge signals: where |edge| >= minEdgePp
+  const edgeSignals = markets.filter(m => Math.abs(m.edge_pp) >= minEdgePp);
+  const edgeCount = edgeSignals.length;
+
+  // Hit rate: edge direction was correct
+  const hits = edgeSignals.filter(m => {
+    if (m.edge_pp > 0) return m.outcome === 1; // model said YES more likely, YES happened
+    return m.outcome === 0; // model said NO more likely, NO happened
+  });
+  const hitRate = edgeCount > 0 ? hits.length / edgeCount : 0;
+
+  // Bootstrap hit rate CI
+  const hitRateData = edgeSignals.map(m => {
+    if (m.edge_pp > 0) return m.outcome === 1 ? 1 : 0;
+    return m.outcome === 0 ? 1 : 0;
+  });
+  const hitRateCI = bootstrapCI(hitRateData, (sample) => {
+    return sample.reduce((a, b) => a + b, 0) / sample.length;
+  });
+
+  // Flat-bet P&L: $1 per edge signal
+  let pnl = 0;
+  for (const m of edgeSignals) {
+    const p = m.market_prob;
+    if (m.edge_pp > 0) {
+      // BUY YES at price P
+      pnl += m.outcome === 1 ? (1 - p) : -p;
+    } else {
+      // BUY NO at price P
+      pnl += m.outcome === 0 ? p : -(1 - p);
+    }
+  }
+  const roi = edgeCount > 0 ? pnl / edgeCount : 0;
+
+  // Unique events
+  const uniqueEvents = new Set(markets.map(m => m.event_ticker));
+
+  // Verdict
+  const significant = skillCI[0] > 0; // CI excludes zero
+  const profitable = pnl > 0;
+  let summary: string;
+  if (skillScore > 0.05 && significant && profitable) {
+    summary = `Model shows edge (Skill +${(skillScore * 100).toFixed(1)}% [CI: +${(skillCI[0] * 100).toFixed(1)}%, +${(skillCI[1] * 100).toFixed(1)}%]; ROI +${(roi * 100).toFixed(1)}%)`;
+  } else if (skillScore > 0 && !significant) {
+    summary = `Inconclusive — need more data (Skill +${(skillScore * 100).toFixed(1)}%, CI includes zero)`;
+  } else {
+    summary = `No edge detected (Skill ${(skillScore * 100).toFixed(1)}%)`;
+  }
+
+  return {
+    verdict: { summary, significant, profitable },
+    brier_octagon: brierOctagon,
+    brier_market: brierMarket,
+    skill_score: skillScore,
+    skill_ci: skillCI,
+    edge_signals: edgeCount,
+    edge_hit_rate: hitRate,
+    hit_rate_ci: hitRateCI,
+    flat_bet_pnl: pnl,
+    flat_bet_roi: roi,
+    markets_evaluated: n,
+    events_evaluated: uniqueEvents.size,
+    coverage: 0, // filled in by caller
+    markets,
+  };
+}

--- a/src/backtest/metrics.ts
+++ b/src/backtest/metrics.ts
@@ -22,6 +22,8 @@ export function bootstrapCI(
   alpha = 0.05,
 ): [number, number] {
   if (data.length === 0) return [0, 0];
+  if (iterations <= 0) throw new Error(`bootstrapCI: iterations must be > 0, got ${iterations}`);
+  if (alpha <= 0 || alpha >= 1) throw new Error(`bootstrapCI: alpha must be in (0, 1), got ${alpha}`);
 
   const stats: number[] = [];
   for (let i = 0; i < iterations; i++) {
@@ -33,8 +35,9 @@ export function bootstrapCI(
   }
   stats.sort((a, b) => a - b);
 
-  const lo = Math.floor((alpha / 2) * stats.length);
-  const hi = Math.floor((1 - alpha / 2) * stats.length);
+  if (stats.length === 0) return [0, 0];
+  const lo = Math.min(Math.max(0, Math.floor((alpha / 2) * stats.length)), stats.length - 1);
+  const hi = Math.min(Math.max(0, Math.floor((1 - alpha / 2) * stats.length)), stats.length - 1);
   return [stats[lo], stats[hi]];
 }
 
@@ -69,25 +72,29 @@ export function computeResolvedMetrics(markets: ResolvedMarket[], minEdgePp = 5)
   const brierOctagon = brierOctagonScores.reduce((a, b) => a + b, 0) / n;
   const brierMarket = brierMarketScores.reduce((a, b) => a + b, 0) / n;
 
-  // Skill score with bootstrap CI
+  // Skill score with bootstrap CI — resample both octagon and market brier scores
   const skillScore = computeSkillScore(brierOctagon, brierMarket);
-
-  // Bootstrap skill: resample paired (octagon_brier, market_brier), compute skill on each
-  const pairedDiffs = markets.map((_, i) => brierMarketScores[i] - brierOctagonScores[i]);
-  const skillCI = bootstrapCI(pairedDiffs, (sample) => {
-    const avgDiff = sample.reduce((a, b) => a + b, 0) / sample.length;
-    const avgMarket = brierMarket; // approximate
-    return avgMarket === 0 ? 0 : avgDiff / avgMarket;
+  const indices = markets.map((_, i) => i);
+  const skillCI = bootstrapCI(indices, (sample) => {
+    let sumOctagon = 0;
+    let sumMarket = 0;
+    for (const idx of sample) {
+      sumOctagon += brierOctagonScores[idx];
+      sumMarket += brierMarketScores[idx];
+    }
+    const avgOctagon = sumOctagon / sample.length;
+    const avgMarket = sumMarket / sample.length;
+    return avgMarket === 0 ? 0 : 1 - (avgOctagon / avgMarket);
   });
 
-  // Edge signals: where |edge| >= minEdgePp
-  const edgeSignals = markets.filter(m => Math.abs(m.edge_pp) >= minEdgePp);
+  // Edge signals: where |edge| >= minEdgePp AND edge is non-zero
+  const edgeSignals = markets.filter(m => m.edge_pp !== 0 && Math.abs(m.edge_pp) >= minEdgePp);
   const edgeCount = edgeSignals.length;
 
   // Hit rate: edge direction was correct
   const hits = edgeSignals.filter(m => {
-    if (m.edge_pp > 0) return m.outcome === 1; // model said YES more likely, YES happened
-    return m.outcome === 0; // model said NO more likely, NO happened
+    if (m.edge_pp > 0) return m.outcome === 1;
+    return m.outcome === 0;
   });
   const hitRate = edgeCount > 0 ? hits.length / edgeCount : 0;
 
@@ -101,6 +108,7 @@ export function computeResolvedMetrics(markets: ResolvedMarket[], minEdgePp = 5)
   });
 
   // Flat-bet P&L: $1 per edge signal
+  const stakePerEdge = 1;
   let pnl = 0;
   for (const m of edgeSignals) {
     const p = m.market_prob;
@@ -112,7 +120,8 @@ export function computeResolvedMetrics(markets: ResolvedMarket[], minEdgePp = 5)
       pnl += m.outcome === 0 ? p : -(1 - p);
     }
   }
-  const roi = edgeCount > 0 ? pnl / edgeCount : 0;
+  const totalDeployed = edgeCount * stakePerEdge;
+  const roi = totalDeployed > 0 ? pnl / totalDeployed : 0;
 
   // Unique events
   const uniqueEvents = new Set(markets.map(m => m.event_ticker));

--- a/src/backtest/metrics.ts
+++ b/src/backtest/metrics.ts
@@ -22,8 +22,12 @@ export function bootstrapCI(
   alpha = 0.05,
 ): [number, number] {
   if (data.length === 0) return [0, 0];
-  if (iterations <= 0) throw new Error(`bootstrapCI: iterations must be > 0, got ${iterations}`);
-  if (alpha <= 0 || alpha >= 1) throw new Error(`bootstrapCI: alpha must be in (0, 1), got ${alpha}`);
+  if (!Number.isFinite(iterations) || !Number.isInteger(iterations) || iterations <= 0) {
+    throw new Error(`bootstrapCI: iterations must be a finite integer > 0, got ${iterations}`);
+  }
+  if (!Number.isFinite(alpha) || alpha <= 0 || alpha >= 1) {
+    throw new Error(`bootstrapCI: alpha must be a finite number in (0, 1), got ${alpha}`);
+  }
 
   const stats: number[] = [];
   for (let i = 0; i < iterations; i++) {

--- a/src/backtest/metrics.ts
+++ b/src/backtest/metrics.ts
@@ -1,5 +1,4 @@
-import { computeBrier } from '../eval/brier.js';
-import type { ResolvedMarket, ResolvedResult } from './types.js';
+import type { ScoredSignal, BacktestResult } from './types.js';
 
 /**
  * Skill score: how much better Octagon is vs the market as a forecaster.
@@ -46,14 +45,25 @@ export function bootstrapCI(
 }
 
 /**
- * Compute all resolved-market metrics from a list of resolved markets.
- * Each market must have model_prob, market_prob, outcome, edge_pp.
+ * Compute Brier score: ((forecast/100) - (outcome/100))²
+ * Both forecast and outcome are on 0-100 scale.
  */
-export function computeResolvedMetrics(markets: ResolvedMarket[], minEdgePp = 5): ResolvedResult {
-  const n = markets.length;
+function brier(forecast: number, outcome: number): number {
+  return ((forecast / 100) - (outcome / 100)) ** 2;
+}
+
+/**
+ * Compute all backtest metrics from a unified list of scored signals.
+ */
+export function computeMetrics(signals: ScoredSignal[], minEdgePp = 5): Omit<BacktestResult, 'subscription_notice'> {
+  const n = signals.length;
   if (n === 0) {
     return {
-      verdict: { summary: 'No resolved markets with Octagon coverage found.', significant: false, profitable: false },
+      verdict: { summary: 'No markets with Octagon coverage found.', significant: false, profitable: false },
+      days: 0,
+      events_scored: 0,
+      markets_resolved: 0,
+      markets_unresolved: 0,
       brier_octagon: 0,
       brier_market: 0,
       skill_score: 0,
@@ -63,22 +73,19 @@ export function computeResolvedMetrics(markets: ResolvedMarket[], minEdgePp = 5)
       hit_rate_ci: [0, 0],
       flat_bet_pnl: 0,
       flat_bet_roi: 0,
-      markets_evaluated: 0,
-      events_evaluated: 0,
-      coverage: 0,
-      markets: [],
+      signals: [],
     };
   }
 
-  // Brier scores
-  const brierOctagonScores = markets.map(m => computeBrier(m.model_prob, m.outcome));
-  const brierMarketScores = markets.map(m => computeBrier(m.market_prob, m.outcome));
+  // Brier scores — model vs market, both compared to outcome (market_now)
+  const brierOctagonScores = signals.map(s => brier(s.model_prob, s.market_now));
+  const brierMarketScores = signals.map(s => brier(s.market_then, s.market_now));
   const brierOctagon = brierOctagonScores.reduce((a, b) => a + b, 0) / n;
   const brierMarket = brierMarketScores.reduce((a, b) => a + b, 0) / n;
 
-  // Skill score with bootstrap CI — resample both octagon and market brier scores
+  // Skill score with bootstrap CI — resample both
   const skillScore = computeSkillScore(brierOctagon, brierMarket);
-  const indices = markets.map((_, i) => i);
+  const indices = signals.map((_, i) => i);
   const skillCI = bootstrapCI(indices, (sample) => {
     let sumOctagon = 0;
     let sumMarket = 0;
@@ -92,50 +99,42 @@ export function computeResolvedMetrics(markets: ResolvedMarket[], minEdgePp = 5)
   });
 
   // Edge signals: where |edge| >= minEdgePp AND edge is non-zero
-  const edgeSignals = markets.filter(m => m.edge_pp !== 0 && Math.abs(m.edge_pp) >= minEdgePp);
+  const edgeSignals = signals.filter(s => s.edge_pp !== 0 && Math.abs(s.edge_pp) >= minEdgePp);
   const edgeCount = edgeSignals.length;
 
-  // Hit rate: edge direction was correct
-  const hits = edgeSignals.filter(m => {
-    if (m.edge_pp > 0) return m.outcome === 1;
-    return m.outcome === 0;
+  // Hit rate: did the market move in the direction the model predicted?
+  const hits = edgeSignals.filter(s => {
+    // Model said YES (edge > 0): hit if market_now > market_then
+    // Model said NO (edge < 0): hit if market_now < market_then
+    if (s.edge_pp > 0) return s.market_now > s.market_then;
+    return s.market_now < s.market_then;
   });
   const hitRate = edgeCount > 0 ? hits.length / edgeCount : 0;
 
   // Bootstrap hit rate CI
-  const hitRateData = edgeSignals.map(m => {
-    if (m.edge_pp > 0) return m.outcome === 1 ? 1 : 0;
-    return m.outcome === 0 ? 1 : 0;
+  const hitRateData = edgeSignals.map(s => {
+    if (s.edge_pp > 0) return s.market_now > s.market_then ? 1 : 0;
+    return s.market_now < s.market_then ? 1 : 0;
   });
   const hitRateCI = bootstrapCI(hitRateData, (sample) => {
     return sample.reduce((a, b) => a + b, 0) / sample.length;
   });
 
-  // Flat-bet P&L: $1 per edge signal
-  const stakePerEdge = 1;
-  let pnl = 0;
-  for (const m of edgeSignals) {
-    const p = m.market_prob;
-    if (m.edge_pp > 0) {
-      // BUY YES at price P
-      pnl += m.outcome === 1 ? (1 - p) : -p;
-    } else {
-      // BUY NO at price P
-      pnl += m.outcome === 0 ? p : -(1 - p);
-    }
-  }
-  const totalDeployed = edgeCount * stakePerEdge;
-  const roi = totalDeployed > 0 ? pnl / totalDeployed : 0;
+  // P&L: already computed per signal
+  const pnl = edgeSignals.reduce((sum, s) => sum + s.pnl, 0);
+  const roi = edgeCount > 0 ? pnl / edgeCount : 0;
 
-  // Unique events
-  const uniqueEvents = new Set(markets.map(m => m.event_ticker));
+  // Counts
+  const uniqueEvents = new Set(signals.map(s => s.event_ticker));
+  const resolved = signals.filter(s => s.resolved).length;
+  const unresolved = signals.filter(s => !s.resolved).length;
 
   // Verdict
-  const significant = skillCI[0] > 0; // CI excludes zero
+  const significant = skillCI[0] > 0;
   const profitable = pnl > 0;
   let summary: string;
   if (skillScore > 0.05 && significant && profitable) {
-    summary = `Model shows edge (Skill +${(skillScore * 100).toFixed(1)}% [CI: +${(skillCI[0] * 100).toFixed(1)}%, +${(skillCI[1] * 100).toFixed(1)}%]; ROI +${(roi * 100).toFixed(1)}%)`;
+    summary = `Model has edge (Skill +${(skillScore * 100).toFixed(1)}% [CI: +${(skillCI[0] * 100).toFixed(1)}%, +${(skillCI[1] * 100).toFixed(1)}%]; ROI +${(roi * 100).toFixed(1)}%)`;
   } else if (skillScore > 0 && !significant) {
     summary = `Inconclusive — need more data (Skill +${(skillScore * 100).toFixed(1)}%, CI includes zero)`;
   } else {
@@ -144,6 +143,10 @@ export function computeResolvedMetrics(markets: ResolvedMarket[], minEdgePp = 5)
 
   return {
     verdict: { summary, significant, profitable },
+    days: 0, // filled by caller
+    events_scored: uniqueEvents.size,
+    markets_resolved: resolved,
+    markets_unresolved: unresolved,
     brier_octagon: brierOctagon,
     brier_market: brierMarket,
     skill_score: skillScore,
@@ -153,9 +156,6 @@ export function computeResolvedMetrics(markets: ResolvedMarket[], minEdgePp = 5)
     hit_rate_ci: hitRateCI,
     flat_bet_pnl: pnl,
     flat_bet_roi: roi,
-    markets_evaluated: n,
-    events_evaluated: uniqueEvents.size,
-    coverage: 0, // filled in by caller
-    markets,
+    signals,
   };
 }

--- a/src/backtest/renderer.ts
+++ b/src/backtest/renderer.ts
@@ -105,7 +105,6 @@ function formatTimeUntil(isoDate: string): string {
   if (diff <= 0) return 'closed';
   const days = diff / (1000 * 60 * 60 * 24);
   if (days >= 365) return `${(days / 365).toFixed(1)} yrs`;
-  if (days >= 30) return `${Math.round(days)} days`;
   if (days >= 1) return `${Math.round(days)} days`;
   const hours = diff / (1000 * 60 * 60);
   return `${Math.round(hours)}h`;

--- a/src/backtest/renderer.ts
+++ b/src/backtest/renderer.ts
@@ -1,10 +1,10 @@
-import type { BacktestResult, UnresolvedEdge } from './types.js';
+import type { BacktestResult, UnresolvedEdge, ResolvedMarket } from './types.js';
 import { writeFileSync } from 'fs';
 
 /**
  * Format the resolved scorecard for terminal display.
  */
-function formatResolved(r: NonNullable<BacktestResult['resolved']>): string {
+function formatResolved(r: NonNullable<BacktestResult['resolved']>, snapshotLabel: string): string {
   const lines: string[] = [];
   lines.push('RESOLVED — Model Scorecard');
   lines.push('──────────────────────────');
@@ -12,6 +12,7 @@ function formatResolved(r: NonNullable<BacktestResult['resolved']>): string {
   lines.push('');
   lines.push(`  Markets        ${r.markets_evaluated}  (${r.events_evaluated} events)`);
   lines.push(`  Coverage       ${(r.coverage * 100).toFixed(0)}%  of settled Kalshi markets`);
+  lines.push(`  Snapshot       ${snapshotLabel}`);
   lines.push('');
   lines.push(`  Brier (Octagon)   ${r.brier_octagon.toFixed(3)}`);
   lines.push(`  Brier (Market)    ${r.brier_market.toFixed(3)}`);
@@ -21,6 +22,24 @@ function formatResolved(r: NonNullable<BacktestResult['resolved']>): string {
   if (r.edge_signals > 0) {
     lines.push(`  Hit rate          ${(r.edge_hit_rate * 100).toFixed(1)}%   [95% CI: ${(r.hit_rate_ci[0] * 100).toFixed(1)}% to ${(r.hit_rate_ci[1] * 100).toFixed(1)}%]`);
     lines.push(`  Flat-bet P&L      ${r.flat_bet_pnl >= 0 ? '+' : ''}$${r.flat_bet_pnl.toFixed(2)} (ROI: ${r.flat_bet_roi >= 0 ? '+' : ''}${(r.flat_bet_roi * 100).toFixed(1)}%)`);
+  }
+
+  // Category breakdown
+  const byCat = new Map<string, ResolvedMarket[]>();
+  for (const m of r.markets) {
+    const cat = m.series_category || 'other';
+    const arr = byCat.get(cat) ?? [];
+    arr.push(m);
+    byCat.set(cat, arr);
+  }
+  if (byCat.size > 1) {
+    lines.push('');
+    lines.push('  By category:');
+    const sorted = [...byCat.entries()].sort((a, b) => b[1].length - a[1].length);
+    for (const [cat, markets] of sorted) {
+      const events = new Set(markets.map(m => m.event_ticker)).size;
+      lines.push(`    ${cat.padEnd(20)} ${String(markets.length).padStart(4)} markets  (${events} events)`);
+    }
   }
 
   return lines.join('\n');
@@ -92,23 +111,30 @@ function formatTimeUntil(isoDate: string): string {
   return `${Math.round(hours)}h`;
 }
 
+export interface FormatOpts {
+  minEdge?: number;          // 0-1 scale, default 0.05
+  minHoursBeforeClose?: number;
+  snapshotLast?: boolean;
+}
+
 /**
  * Format complete backtest result for terminal display.
  */
-export function formatBacktestHuman(result: BacktestResult): string {
+export function formatBacktestHuman(result: BacktestResult, opts?: FormatOpts): string {
+  const minEdge = opts?.minEdge ?? 0.05;
+  const snapshotLabel = opts?.snapshotLast ? 'last (no lead time)' : `last-${opts?.minHoursBeforeClose ?? 24}h`;
   const lines: string[] = [];
   lines.push(`Octagon Backtest — ${result.date_range.from} – ${result.date_range.to}`);
   lines.push('═══════════════════════════════════════');
   lines.push('');
 
   if (result.resolved) {
-    lines.push(formatResolved(result.resolved));
+    lines.push(formatResolved(result.resolved, snapshotLabel));
     lines.push('');
   }
 
   if (result.unresolved) {
-    // Use default 5pp min edge for display
-    lines.push(formatUnresolved(result.unresolved, 0.05));
+    lines.push(formatUnresolved(result.unresolved, minEdge));
   }
 
   if (!result.resolved && !result.unresolved) {

--- a/src/backtest/renderer.ts
+++ b/src/backtest/renderer.ts
@@ -129,7 +129,12 @@ export function formatBacktestHuman(result: BacktestResult, opts?: FormatOpts): 
   lines.push('═══════════════════════════════════════');
   lines.push('');
 
-  if (result.resolved) {
+  if (result.subscription_notice) {
+    lines.push('RESOLVED — Model Scorecard');
+    lines.push('──────────────────────────');
+    lines.push(`  ${result.subscription_notice}`);
+    lines.push('');
+  } else if (result.resolved) {
     lines.push(formatResolved(result.resolved, snapshotLabel));
     lines.push('');
   }
@@ -138,7 +143,7 @@ export function formatBacktestHuman(result: BacktestResult, opts?: FormatOpts): 
     lines.push(formatUnresolved(result.unresolved, minEdge));
   }
 
-  if (!result.resolved && !result.unresolved) {
+  if (!result.resolved && !result.unresolved && !result.subscription_notice) {
     lines.push('No data available. Run `bun start backtest` with a broader filter.');
   }
 

--- a/src/backtest/renderer.ts
+++ b/src/backtest/renderer.ts
@@ -1,150 +1,140 @@
-import type { BacktestResult, UnresolvedEdge, ResolvedMarket } from './types.js';
+import type { BacktestResult, ScoredSignal } from './types.js';
 import { writeFileSync } from 'fs';
-
-/**
- * Format the resolved scorecard for terminal display.
- */
-function formatResolved(r: NonNullable<BacktestResult['resolved']>, snapshotLabel: string): string {
-  const lines: string[] = [];
-  lines.push('RESOLVED — Model Scorecard');
-  lines.push('──────────────────────────');
-  lines.push(`VERDICT: ${r.verdict.summary}`);
-  lines.push('');
-  lines.push(`  Markets        ${r.markets_evaluated}  (${r.events_evaluated} events)`);
-  lines.push(`  Coverage       ${(r.coverage * 100).toFixed(0)}%  of settled Kalshi markets`);
-  lines.push(`  Snapshot       ${snapshotLabel}`);
-  lines.push('');
-  lines.push(`  Brier (Octagon)   ${r.brier_octagon.toFixed(3)}`);
-  lines.push(`  Brier (Market)    ${r.brier_market.toFixed(3)}`);
-  lines.push(`  Skill Score       ${r.skill_score >= 0 ? '+' : ''}${(r.skill_score * 100).toFixed(1)}%  [95% CI: ${(r.skill_ci[0] * 100).toFixed(1)}% to ${(r.skill_ci[1] * 100).toFixed(1)}%]`);
-  lines.push('');
-  lines.push(`  Edge signals      ${r.edge_signals}`);
-  if (r.edge_signals > 0) {
-    lines.push(`  Hit rate          ${(r.edge_hit_rate * 100).toFixed(1)}%   [95% CI: ${(r.hit_rate_ci[0] * 100).toFixed(1)}% to ${(r.hit_rate_ci[1] * 100).toFixed(1)}%]`);
-    lines.push(`  Flat-bet P&L      ${r.flat_bet_pnl >= 0 ? '+' : ''}$${r.flat_bet_pnl.toFixed(2)} (ROI: ${r.flat_bet_roi >= 0 ? '+' : ''}${(r.flat_bet_roi * 100).toFixed(1)}%)`);
-  }
-
-  // Category breakdown
-  const byCat = new Map<string, ResolvedMarket[]>();
-  for (const m of r.markets) {
-    const cat = m.series_category || 'other';
-    const arr = byCat.get(cat) ?? [];
-    arr.push(m);
-    byCat.set(cat, arr);
-  }
-  if (byCat.size > 1) {
-    lines.push('');
-    lines.push('  By category:');
-    const sorted = [...byCat.entries()].sort((a, b) => b[1].length - a[1].length);
-    for (const [cat, markets] of sorted) {
-      const events = new Set(markets.map(m => m.event_ticker)).size;
-      lines.push(`    ${cat.padEnd(20)} ${String(markets.length).padStart(4)} markets  (${events} events)`);
-    }
-  }
-
-  return lines.join('\n');
-}
-
-/**
- * Format the unresolved edge scanner for terminal display.
- */
-function formatUnresolved(u: NonNullable<BacktestResult['unresolved']>, minEdge: number): string {
-  const lines: string[] = [];
-  const minPp = (minEdge * 100).toFixed(0);
-  lines.push(`UNRESOLVED — Live Edge Scanner (min edge: ${minPp}pp)`);
-  lines.push('──────────────────────────────────────────────');
-
-  if (u.edges.length === 0) {
-    lines.push('  No markets with edge above threshold.');
-    return lines.join('\n');
-  }
-
-  // Header
-  const header = '  ' + [
-    'Ticker'.padEnd(30),
-    'Model'.padStart(6),
-    'Market'.padStart(7),
-    'Edge'.padStart(7),
-    'Dir'.padStart(6),
-    'Conf'.padStart(6),
-    'Closes'.padStart(12),
-  ].join('  ');
-  lines.push(header);
-
-  for (const e of u.edges) {
-    const dir = e.direction === 'YES' ? 'YES ▲' : 'NO  ▼';
-    const closes = formatTimeUntil(e.closes_at);
-    const confLabel = formatConfidence(e.confidence_score);
-
-    const row = '  ' + [
-      e.ticker.padEnd(30),
-      `${(e.model_prob * 100).toFixed(0)}%`.padStart(6),
-      `${(e.market_prob * 100).toFixed(0)}%`.padStart(7),
-      `${e.edge_pp >= 0 ? '+' : ''}${e.edge_pp.toFixed(0)}pp`.padStart(7),
-      dir.padStart(6),
-      confLabel.padStart(6),
-      closes.padStart(12),
-    ].join('  ');
-    lines.push(row);
-  }
-
-  lines.push('');
-  lines.push(`  ${u.edges.length} markets with edge ≥ ${minPp}pp (of ${u.total_open_with_coverage} open markets with Octagon coverage)`);
-
-  return lines.join('\n');
-}
-
-function formatConfidence(score: number): string {
-  if (score >= 8) return 'high';
-  if (score >= 5) return 'med';
-  return 'low';
-}
-
-function formatTimeUntil(isoDate: string): string {
-  const diff = new Date(isoDate).getTime() - Date.now();
-  if (diff <= 0) return 'closed';
-  const days = diff / (1000 * 60 * 60 * 24);
-  if (days >= 365) return `${(days / 365).toFixed(1)} yrs`;
-  if (days >= 1) return `${Math.round(days)} days`;
-  const hours = diff / (1000 * 60 * 60);
-  if (hours >= 1) return `${Math.round(hours)}h`;
-  const minutes = diff / (1000 * 60);
-  return minutes >= 1 ? `${Math.round(minutes)}m` : '< 1m';
-}
 
 export interface FormatOpts {
   minEdge?: number;          // 0-1 scale, default 0.05
-  minHoursBeforeClose?: number;
-  snapshotLast?: boolean;
 }
 
 /**
  * Format complete backtest result for terminal display.
  */
 export function formatBacktestHuman(result: BacktestResult, opts?: FormatOpts): string {
-  const minEdge = opts?.minEdge ?? 0.05;
-  const snapshotLabel = opts?.snapshotLast ? 'last (no lead time)' : `last-${opts?.minHoursBeforeClose ?? 24}h`;
+  const minEdgePp = ((opts?.minEdge ?? 0.05) * 100).toFixed(0);
+  const now = new Date();
+  const from = new Date(now.getTime() - result.days * 24 * 60 * 60 * 1000);
+  const fromStr = from.toISOString().slice(5, 10).replace('-', '/');
+  const toStr = now.toISOString().slice(5, 10).replace('-', '/');
+
   const lines: string[] = [];
-  lines.push(`Octagon Backtest — ${result.date_range.from} – ${result.date_range.to}`);
-  lines.push('═══════════════════════════════════════');
+  lines.push(`Octagon Backtest — ${result.days}-day lookback (${fromStr} – ${toStr})`);
+  lines.push('══════════════════════════════════════════════════════════');
   lines.push('');
 
   if (result.subscription_notice) {
-    lines.push('RESOLVED — Model Scorecard');
-    lines.push('──────────────────────────');
     lines.push(`  ${result.subscription_notice}`);
     lines.push('');
-  } else if (result.resolved) {
-    lines.push(formatResolved(result.resolved, snapshotLabel));
+    // Still show unresolved signals if any
+    const unresolvedSignals = result.signals.filter(s => !s.resolved);
+    if (unresolvedSignals.length > 0) {
+      lines.push(formatUnresolvedTable(unresolvedSignals, minEdgePp));
+    }
+    return lines.join('\n');
+  }
+
+  if (result.signals.length === 0) {
+    lines.push('No data available. Try a longer lookback (--days 60) or broader filter.');
+    return lines.join('\n');
+  }
+
+  // Unified scorecard
+  lines.push(`VERDICT: ${result.verdict.summary}`);
+  lines.push('');
+  lines.push(`  Events         ${result.events_scored}`);
+  lines.push(`  Markets        ${result.markets_resolved + result.markets_unresolved}   (${result.markets_resolved} resolved, ${result.markets_unresolved} unresolved)`);
+  lines.push('');
+  lines.push(`  Brier (Octagon)   ${result.brier_octagon.toFixed(3)}`);
+  lines.push(`  Brier (Market)    ${result.brier_market.toFixed(3)}`);
+  lines.push(`  Skill Score       ${result.skill_score >= 0 ? '+' : ''}${(result.skill_score * 100).toFixed(1)}%  [95% CI: ${(result.skill_ci[0] * 100).toFixed(1)}% to ${(result.skill_ci[1] * 100).toFixed(1)}%]`);
+  lines.push('');
+  lines.push(`  Edge signals      ${result.edge_signals}   (min edge: ${minEdgePp}pp)`);
+  if (result.edge_signals > 0) {
+    lines.push(`  Hit rate          ${(result.edge_hit_rate * 100).toFixed(1)}%  [95% CI: ${(result.hit_rate_ci[0] * 100).toFixed(1)}% to ${(result.hit_rate_ci[1] * 100).toFixed(1)}%]`);
+    lines.push(`  Flat-bet P&L      ${result.flat_bet_pnl >= 0 ? '+' : ''}$${result.flat_bet_pnl.toFixed(2)} (ROI: ${result.flat_bet_roi >= 0 ? '+' : ''}${(result.flat_bet_roi * 100).toFixed(1)}%)`);
+  }
+
+  // Resolved detail table
+  const resolved = result.signals.filter(s => s.resolved);
+  if (resolved.length > 0) {
     lines.push('');
+    lines.push(formatResolvedTable(resolved));
   }
 
-  if (result.unresolved) {
-    lines.push(formatUnresolved(result.unresolved, minEdge));
+  // Unresolved detail table
+  const unresolved = result.signals.filter(s => !s.resolved);
+  if (unresolved.length > 0) {
+    lines.push('');
+    lines.push(formatUnresolvedTable(unresolved, minEdgePp));
   }
 
-  if (!result.resolved && !result.unresolved && !result.subscription_notice) {
-    lines.push('No data available. Run `bun start backtest` with a broader filter.');
+  return lines.join('\n');
+}
+
+function formatResolvedTable(signals: ScoredSignal[]): string {
+  const lines: string[] = [];
+  lines.push(`RESOLVED (${signals.length} markets — scored against Kalshi settlement)`);
+  lines.push('─────────────────────────────────────────────────────────');
+
+  const header = '  ' + [
+    'Ticker'.padEnd(30),
+    'Model'.padStart(6),
+    'Mkt Then'.padStart(9),
+    'Outcome'.padStart(10),
+    'Edge'.padStart(7),
+    'P&L'.padStart(8),
+  ].join('  ');
+  lines.push(header);
+
+  // Sort by |P&L| descending
+  const sorted = [...signals].sort((a, b) => Math.abs(b.pnl) - Math.abs(a.pnl));
+  for (const s of sorted.slice(0, 20)) {
+    const outcome = s.market_now === 100 ? 'YES 100%' : 'NO  0%';
+    const row = '  ' + [
+      s.market_ticker.padEnd(30),
+      `${s.model_prob.toFixed(0)}%`.padStart(6),
+      `${s.market_then.toFixed(0)}%`.padStart(9),
+      outcome.padStart(10),
+      `${s.edge_pp >= 0 ? '+' : ''}${s.edge_pp.toFixed(0)}pp`.padStart(7),
+      `${s.pnl >= 0 ? '+' : ''}$${s.pnl.toFixed(2)}`.padStart(8),
+    ].join('  ');
+    lines.push(row);
+  }
+  if (sorted.length > 20) {
+    lines.push(`  ... and ${sorted.length - 20} more`);
+  }
+
+  return lines.join('\n');
+}
+
+function formatUnresolvedTable(signals: ScoredSignal[], minEdgePp: string): string {
+  const lines: string[] = [];
+  lines.push(`UNRESOLVED (${signals.length} markets — mark-to-market vs Kalshi trading price)`);
+  lines.push('────────────────────────────────────────────────────────────────');
+
+  const header = '  ' + [
+    'Ticker'.padEnd(30),
+    'Model'.padStart(6),
+    'Mkt Then'.padStart(9),
+    'Now'.padStart(6),
+    'Edge'.padStart(7),
+    'M2M'.padStart(8),
+  ].join('  ');
+  lines.push(header);
+
+  // Sort by |edge| descending
+  const sorted = [...signals].sort((a, b) => Math.abs(b.edge_pp) - Math.abs(a.edge_pp));
+  for (const s of sorted.slice(0, 20)) {
+    const row = '  ' + [
+      s.market_ticker.padEnd(30),
+      `${s.model_prob.toFixed(0)}%`.padStart(6),
+      `${s.market_then.toFixed(0)}%`.padStart(9),
+      `${s.market_now.toFixed(0)}%`.padStart(6),
+      `${s.edge_pp >= 0 ? '+' : ''}${s.edge_pp.toFixed(0)}pp`.padStart(7),
+      `${s.pnl >= 0 ? '+' : ''}$${s.pnl.toFixed(2)}`.padStart(8),
+    ].join('  ');
+    lines.push(row);
+  }
+  if (sorted.length > 20) {
+    lines.push(`  ... and ${sorted.length - 20} more`);
   }
 
   return lines.join('\n');
@@ -164,38 +154,22 @@ function csvEscape(val: string | number): string {
  */
 export function exportCSV(result: BacktestResult, path: string): void {
   const rows: string[] = [];
-  rows.push('type,ticker,event_ticker,model_prob,market_prob,edge_pp,outcome,close_time,series_category');
+  rows.push('type,ticker,event_ticker,model_prob,market_then,market_now,edge_pp,pnl,resolved,close_time,series_category');
 
-  if (result.resolved) {
-    for (const m of result.resolved.markets) {
-      rows.push([
-        'resolved',
-        csvEscape(m.ticker),
-        csvEscape(m.event_ticker),
-        m.model_prob.toFixed(4),
-        m.market_prob.toFixed(4),
-        m.edge_pp.toFixed(1),
-        m.outcome,
-        csvEscape(m.close_time),
-        csvEscape(m.series_category),
-      ].join(','));
-    }
-  }
-
-  if (result.unresolved) {
-    for (const e of result.unresolved.edges) {
-      rows.push([
-        'unresolved',
-        csvEscape(e.ticker),
-        csvEscape(e.event_ticker),
-        e.model_prob.toFixed(4),
-        e.market_prob.toFixed(4),
-        e.edge_pp.toFixed(1),
-        '',
-        csvEscape(e.closes_at),
-        csvEscape(e.series_category),
-      ].join(','));
-    }
+  for (const s of result.signals) {
+    rows.push([
+      s.resolved ? 'resolved' : 'unresolved',
+      csvEscape(s.market_ticker),
+      csvEscape(s.event_ticker),
+      s.model_prob.toFixed(1),
+      s.market_then.toFixed(1),
+      s.market_now.toFixed(1),
+      s.edge_pp.toFixed(1),
+      s.pnl.toFixed(2),
+      s.resolved ? '1' : '0',
+      csvEscape(s.close_time),
+      csvEscape(s.series_category),
+    ].join(','));
   }
 
   writeFileSync(path, rows.join('\n') + '\n');

--- a/src/backtest/renderer.ts
+++ b/src/backtest/renderer.ts
@@ -1,0 +1,161 @@
+import type { BacktestResult, UnresolvedEdge } from './types.js';
+import { writeFileSync } from 'fs';
+
+/**
+ * Format the resolved scorecard for terminal display.
+ */
+function formatResolved(r: NonNullable<BacktestResult['resolved']>): string {
+  const lines: string[] = [];
+  lines.push('RESOLVED — Model Scorecard');
+  lines.push('──────────────────────────');
+  lines.push(`VERDICT: ${r.verdict.summary}`);
+  lines.push('');
+  lines.push(`  Markets        ${r.markets_evaluated}  (${r.events_evaluated} events)`);
+  lines.push(`  Coverage       ${(r.coverage * 100).toFixed(0)}%  of settled Kalshi markets`);
+  lines.push('');
+  lines.push(`  Brier (Octagon)   ${r.brier_octagon.toFixed(3)}`);
+  lines.push(`  Brier (Market)    ${r.brier_market.toFixed(3)}`);
+  lines.push(`  Skill Score       ${r.skill_score >= 0 ? '+' : ''}${(r.skill_score * 100).toFixed(1)}%  [95% CI: ${(r.skill_ci[0] * 100).toFixed(1)}% to ${(r.skill_ci[1] * 100).toFixed(1)}%]`);
+  lines.push('');
+  lines.push(`  Edge signals      ${r.edge_signals}`);
+  if (r.edge_signals > 0) {
+    lines.push(`  Hit rate          ${(r.edge_hit_rate * 100).toFixed(1)}%   [95% CI: ${(r.hit_rate_ci[0] * 100).toFixed(1)}% to ${(r.hit_rate_ci[1] * 100).toFixed(1)}%]`);
+    lines.push(`  Flat-bet P&L      ${r.flat_bet_pnl >= 0 ? '+' : ''}$${r.flat_bet_pnl.toFixed(2)} (ROI: ${r.flat_bet_roi >= 0 ? '+' : ''}${(r.flat_bet_roi * 100).toFixed(1)}%)`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Format the unresolved edge scanner for terminal display.
+ */
+function formatUnresolved(u: NonNullable<BacktestResult['unresolved']>, minEdge: number): string {
+  const lines: string[] = [];
+  const minPp = (minEdge * 100).toFixed(0);
+  lines.push(`UNRESOLVED — Live Edge Scanner (min edge: ${minPp}pp)`);
+  lines.push('──────────────────────────────────────────────');
+
+  if (u.edges.length === 0) {
+    lines.push('  No markets with edge above threshold.');
+    return lines.join('\n');
+  }
+
+  // Header
+  const header = '  ' + [
+    'Ticker'.padEnd(30),
+    'Model'.padStart(6),
+    'Market'.padStart(7),
+    'Edge'.padStart(7),
+    'Dir'.padStart(6),
+    'Conf'.padStart(6),
+    'Closes'.padStart(12),
+  ].join('  ');
+  lines.push(header);
+
+  for (const e of u.edges) {
+    const dir = e.direction === 'YES' ? 'YES ▲' : 'NO  ▼';
+    const closes = formatTimeUntil(e.closes_at);
+    const confLabel = formatConfidence(e.confidence_score);
+
+    const row = '  ' + [
+      e.ticker.padEnd(30),
+      `${(e.model_prob * 100).toFixed(0)}%`.padStart(6),
+      `${(e.market_prob * 100).toFixed(0)}%`.padStart(7),
+      `${e.edge_pp >= 0 ? '+' : ''}${e.edge_pp.toFixed(0)}pp`.padStart(7),
+      dir.padStart(6),
+      confLabel.padStart(6),
+      closes.padStart(12),
+    ].join('  ');
+    lines.push(row);
+  }
+
+  lines.push('');
+  lines.push(`  ${u.edges.length} markets with edge ≥ ${minPp}pp (of ${u.total_open_with_coverage} open markets with Octagon coverage)`);
+
+  return lines.join('\n');
+}
+
+function formatConfidence(score: number): string {
+  if (score >= 8) return 'high';
+  if (score >= 5) return 'med';
+  return 'low';
+}
+
+function formatTimeUntil(isoDate: string): string {
+  const diff = new Date(isoDate).getTime() - Date.now();
+  if (diff <= 0) return 'closed';
+  const days = diff / (1000 * 60 * 60 * 24);
+  if (days >= 365) return `${(days / 365).toFixed(1)} yrs`;
+  if (days >= 30) return `${Math.round(days)} days`;
+  if (days >= 1) return `${Math.round(days)} days`;
+  const hours = diff / (1000 * 60 * 60);
+  return `${Math.round(hours)}h`;
+}
+
+/**
+ * Format complete backtest result for terminal display.
+ */
+export function formatBacktestHuman(result: BacktestResult): string {
+  const lines: string[] = [];
+  lines.push(`Octagon Backtest — ${result.date_range.from} – ${result.date_range.to}`);
+  lines.push('═══════════════════════════════════════');
+  lines.push('');
+
+  if (result.resolved) {
+    lines.push(formatResolved(result.resolved));
+    lines.push('');
+  }
+
+  if (result.unresolved) {
+    // Use default 5pp min edge for display
+    lines.push(formatUnresolved(result.unresolved, 0.05));
+  }
+
+  if (!result.resolved && !result.unresolved) {
+    lines.push('No data available. Run `bun start backtest` with a broader filter.');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Export per-market detail to CSV.
+ */
+export function exportCSV(result: BacktestResult, path: string): void {
+  const rows: string[] = [];
+  rows.push('type,ticker,event_ticker,model_prob,market_prob,edge_pp,outcome,close_time,series_category');
+
+  if (result.resolved) {
+    for (const m of result.resolved.markets) {
+      rows.push([
+        'resolved',
+        m.ticker,
+        m.event_ticker,
+        m.model_prob.toFixed(4),
+        m.market_prob.toFixed(4),
+        m.edge_pp.toFixed(1),
+        m.outcome,
+        m.close_time,
+        m.series_category,
+      ].join(','));
+    }
+  }
+
+  if (result.unresolved) {
+    for (const e of result.unresolved.edges) {
+      rows.push([
+        'unresolved',
+        e.ticker,
+        e.event_ticker,
+        e.model_prob.toFixed(4),
+        e.market_prob.toFixed(4),
+        e.edge_pp.toFixed(1),
+        '',
+        e.closes_at,
+        e.series_category,
+      ].join(','));
+    }
+  }
+
+  writeFileSync(path, rows.join('\n') + '\n');
+}

--- a/src/backtest/renderer.ts
+++ b/src/backtest/renderer.ts
@@ -144,6 +144,15 @@ export function formatBacktestHuman(result: BacktestResult, opts?: FormatOpts): 
   return lines.join('\n');
 }
 
+/** Escape a CSV cell: wrap in quotes if it contains comma, quote, or newline. */
+function csvEscape(val: string | number): string {
+  const s = String(val);
+  if (s.includes(',') || s.includes('"') || s.includes('\n') || s.includes('\r')) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
 /**
  * Export per-market detail to CSV.
  */
@@ -155,14 +164,14 @@ export function exportCSV(result: BacktestResult, path: string): void {
     for (const m of result.resolved.markets) {
       rows.push([
         'resolved',
-        m.ticker,
-        m.event_ticker,
+        csvEscape(m.ticker),
+        csvEscape(m.event_ticker),
         m.model_prob.toFixed(4),
         m.market_prob.toFixed(4),
         m.edge_pp.toFixed(1),
         m.outcome,
-        m.close_time,
-        m.series_category,
+        csvEscape(m.close_time),
+        csvEscape(m.series_category),
       ].join(','));
     }
   }
@@ -171,14 +180,14 @@ export function exportCSV(result: BacktestResult, path: string): void {
     for (const e of result.unresolved.edges) {
       rows.push([
         'unresolved',
-        e.ticker,
-        e.event_ticker,
+        csvEscape(e.ticker),
+        csvEscape(e.event_ticker),
         e.model_prob.toFixed(4),
         e.market_prob.toFixed(4),
         e.edge_pp.toFixed(1),
         '',
-        e.closes_at,
-        e.series_category,
+        csvEscape(e.closes_at),
+        csvEscape(e.series_category),
       ].join(','));
     }
   }

--- a/src/backtest/renderer.ts
+++ b/src/backtest/renderer.ts
@@ -107,7 +107,9 @@ function formatTimeUntil(isoDate: string): string {
   if (days >= 365) return `${(days / 365).toFixed(1)} yrs`;
   if (days >= 1) return `${Math.round(days)} days`;
   const hours = diff / (1000 * 60 * 60);
-  return `${Math.round(hours)}h`;
+  if (hours >= 1) return `${Math.round(hours)}h`;
+  const minutes = diff / (1000 * 60);
+  return minutes >= 1 ? `${Math.round(minutes)}m` : '< 1m';
 }
 
 export interface FormatOpts {

--- a/src/backtest/types.ts
+++ b/src/backtest/types.ts
@@ -1,0 +1,67 @@
+export interface BacktestOpts {
+  resolvedOnly: boolean;
+  unresolvedOnly: boolean;
+  from?: string;          // ISO date
+  to?: string;            // ISO date
+  category?: string;
+  minHoursBeforeClose: number;  // default 24
+  minEdge: number;              // default 0.05 (5pp)
+  exportPath?: string;
+}
+
+export interface BacktestSnapshot {
+  ticker: string;
+  event_ticker: string;
+  model_prob: number;       // 0-1
+  market_prob: number;      // 0-1
+  edge_pp: number;          // percentage points
+  hours_before_close: number;
+  confidence_score: number;
+  series_category: string;
+}
+
+export interface ResolvedMarket extends BacktestSnapshot {
+  outcome: 0 | 1;          // YES=1, NO=0
+  close_time: string;       // ISO 8601
+}
+
+export interface UnresolvedEdge {
+  ticker: string;
+  event_ticker: string;
+  model_prob: number;
+  market_prob: number;
+  edge_pp: number;
+  direction: 'YES' | 'NO';
+  confidence_score: number;
+  closes_at: string;
+  series_category: string;
+}
+
+export interface ResolvedResult {
+  verdict: { summary: string; significant: boolean; profitable: boolean };
+  brier_octagon: number;
+  brier_market: number;
+  skill_score: number;
+  skill_ci: [number, number];
+  edge_signals: number;
+  edge_hit_rate: number;
+  hit_rate_ci: [number, number];
+  flat_bet_pnl: number;
+  flat_bet_roi: number;
+  markets_evaluated: number;
+  events_evaluated: number;
+  coverage: number;       // fraction of settled markets with Octagon history
+  markets: ResolvedMarket[];  // per-market detail for CSV export
+}
+
+export interface UnresolvedResult {
+  edges: UnresolvedEdge[];
+  total_open_with_coverage: number;
+  total_open: number;
+}
+
+export interface BacktestResult {
+  resolved: ResolvedResult | null;
+  unresolved: UnresolvedResult | null;
+  date_range: { from: string; to: string };
+}

--- a/src/backtest/types.ts
+++ b/src/backtest/types.ts
@@ -3,7 +3,7 @@ export interface BacktestOpts {
   resolvedOnly: boolean;
   unresolvedOnly: boolean;
   category?: string;
-  minEdge: number;            // 0-1 scale (e.g., 0.05 = 5pp)
+  minEdge: number;            // fractional (0-1 scale), converted to pp by caller (e.g., 0.05 → 5pp)
   exportPath?: string;
 }
 

--- a/src/backtest/types.ts
+++ b/src/backtest/types.ts
@@ -1,44 +1,33 @@
 export interface BacktestOpts {
+  days: number;               // lookback period in days (default 30)
   resolvedOnly: boolean;
   unresolvedOnly: boolean;
-  from?: string;          // ISO date
-  to?: string;            // ISO date
   category?: string;
-  minHoursBeforeClose: number;  // default 24
-  minEdge: number;              // default 0.05 (5pp)
+  minEdge: number;            // 0-1 scale (e.g., 0.05 = 5pp)
   exportPath?: string;
 }
 
-export interface BacktestSnapshot {
-  ticker: string;
+/** A single scored market signal — unified type for both resolved and unresolved. */
+export interface ScoredSignal {
   event_ticker: string;
-  model_prob: number;       // 0-1
-  market_prob: number;      // 0-1
-  edge_pp: number;          // percentage points
-  hours_before_close: number;
-  confidence_score: number;
+  market_ticker: string;
   series_category: string;
-}
-
-export interface ResolvedMarket extends BacktestSnapshot {
-  outcome: 0 | 1;          // YES=1, NO=0
-  close_time: string;       // ISO 8601
-}
-
-export interface UnresolvedEdge {
-  ticker: string;
-  event_ticker: string;
-  model_prob: number;
-  market_prob: number;
-  edge_pp: number;
-  direction: 'YES' | 'NO';
+  model_prob: number;         // 0-100 (Octagon model % from N days ago)
+  market_then: number;        // 0-100 (Kalshi trading price N days ago, from Octagon snapshot)
+  market_now: number;         // 0-100 (settlement for resolved, current price for unresolved)
+  resolved: boolean;
+  edge_pp: number;            // model_prob - market_then
+  pnl: number;               // computed P&L for this signal
   confidence_score: number;
-  closes_at: string;
-  series_category: string;
+  close_time: string;
 }
 
-export interface ResolvedResult {
+export interface BacktestResult {
   verdict: { summary: string; significant: boolean; profitable: boolean };
+  days: number;
+  events_scored: number;
+  markets_resolved: number;
+  markets_unresolved: number;
   brier_octagon: number;
   brier_market: number;
   skill_score: number;
@@ -48,21 +37,6 @@ export interface ResolvedResult {
   hit_rate_ci: [number, number];
   flat_bet_pnl: number;
   flat_bet_roi: number;
-  markets_evaluated: number;
-  events_evaluated: number;
-  coverage: number;       // fraction of settled markets with Octagon history
-  markets: ResolvedMarket[];  // per-market detail for CSV export
-}
-
-export interface UnresolvedResult {
-  edges: UnresolvedEdge[];
-  total_open_with_coverage: number;
-  total_open: number;
-}
-
-export interface BacktestResult {
-  resolved: ResolvedResult | null;
-  unresolved: UnresolvedResult | null;
-  date_range: { from: string; to: string };
+  signals: ScoredSignal[];
   subscription_notice?: string;
 }

--- a/src/backtest/types.ts
+++ b/src/backtest/types.ts
@@ -64,4 +64,5 @@ export interface BacktestResult {
   resolved: ResolvedResult | null;
   unresolved: UnresolvedResult | null;
   date_range: { from: string; to: string };
+  subscription_notice?: string;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -472,10 +472,22 @@ export async function runCli(options?: { forceSetup?: boolean }) {
         workingIndicator.setState({ status: 'thinking' });
         tui.requestRender();
         const cmdResult = await handleSlashCommand(query);
-        workingIndicator.setState({ status: 'idle' });
         if (cmdResult !== null) {
           const formatted = formatResponse(cmdResult.output);
           chatLog.finalizeAnswer(formatted);
+          tui.requestRender();
+
+          // If the command has an async follow-up (e.g., backtest), run it with the spinner still active
+          if (cmdResult.asyncFollowUp) {
+            try {
+              const followUp = await cmdResult.asyncFollowUp();
+              chatLog.finalizeAnswer(formatResponse(followUp));
+            } catch (err) {
+              chatLog.finalizeAnswer(`Error: ${err instanceof Error ? err.message : String(err)}`);
+            }
+          }
+
+          workingIndicator.setState({ status: 'idle' });
           if (cmdResult.pendingTrade) {
             pendingTrade = cmdResult.pendingTrade;
             chatLog.finalizeAnswer(
@@ -487,6 +499,7 @@ export async function runCli(options?: { forceSetup?: boolean }) {
           tui.requestRender();
           return;
         }
+        workingIndicator.setState({ status: 'idle' });
       } catch (err) {
         workingIndicator.setState({ status: 'idle' });
         chatLog.finalizeAnswer(`Error: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -412,6 +412,36 @@ export async function runCli(options?: { forceSetup?: boolean }) {
 
     if (query.startsWith('/search')) {
       const themeArg = query.slice('/search'.length).trim() || 'top50';
+      // /search edge → edge scanner (inline, no browse flow)
+      if (themeArg.startsWith('edge')) {
+        chatLog.addQuery(query);
+        chatLog.resetToolGrouping();
+        try {
+          workingIndicator.setState({ status: 'thinking' });
+          tui.requestRender();
+          // Parse edge-specific flags from the rest of the args
+          const edgeArgs = themeArg.slice('edge'.length).trim().split(/\s+/).filter(Boolean);
+          let minEdgePp = 5;
+          let edgeLimit = 20;
+          let edgeCategory: string | undefined;
+          for (let i = 0; i < edgeArgs.length; i++) {
+            if (edgeArgs[i] === '--min-edge') { const v = Number(edgeArgs[++i]?.replace('%', '')); if (Number.isFinite(v)) minEdgePp = v; }
+            else if (edgeArgs[i] === '--limit') { const v = Number(edgeArgs[++i]); if (Number.isFinite(v) && v > 0) edgeLimit = v; }
+            else if (edgeArgs[i] === '--category') { edgeCategory = edgeArgs[++i]; }
+          }
+          const { scanEdges, formatEdgeScanHuman } = await import('./commands/search-edge.js');
+          const { getDb } = await import('./db/index.js');
+          const result = scanEdges(getDb(), { minEdgePp, limit: edgeLimit, category: edgeCategory });
+          workingIndicator.setState({ status: 'idle' });
+          chatLog.finalizeAnswer(formatResponse(formatEdgeScanHuman(result, minEdgePp)));
+          tui.requestRender();
+        } catch (err) {
+          workingIndicator.setState({ status: 'idle' });
+          chatLog.finalizeAnswer(`Error: ${err instanceof Error ? err.message : String(err)}`);
+          tui.requestRender();
+        }
+        return;
+      }
       // /search themes → inline themes list (no browse flow)
       if (themeArg === 'themes') {
         // Handled as slash command in handleSlashCommand via 'themes' case

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -365,6 +365,8 @@ export async function runCli(options?: { forceSetup?: boolean }) {
     { name: 'buy', description: 'Buy contracts (defaults to YES side)', getArgumentCompletions: usageHint('<ticker> <count> [price] [yes|no]', 'e.g. KXBTC-26MAR14-T50049 10 56') },
     { name: 'sell', description: 'Sell contracts (defaults to YES side)', getArgumentCompletions: usageHint('<ticker> <count> [price] [yes|no]', 'e.g. KXBTC-26MAR14-T50049 10 56') },
     { name: 'cancel', description: 'Cancel a resting order', getArgumentCompletions: usageHint('<order_id>', 'the order UUID') },
+    // Analysis
+    { name: 'backtest', description: 'Model accuracy scorecard + live edge scanner' },
     // Utility
     { name: 'help', description: 'Show help (/help <command> for details)', getArgumentCompletions: helpTopicCompletions },
     { name: 'model', description: 'Change LLM model/provider', getArgumentCompletions: usageHint('<provider:model>', 'e.g. anthropic:sonnet') },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -504,15 +504,18 @@ export async function runCli(options?: { forceSetup?: boolean }) {
         const cmdResult = await handleSlashCommand(query);
         if (cmdResult !== null) {
           const formatted = formatResponse(cmdResult.output);
-          chatLog.finalizeAnswer(formatted);
+          const answerBox = chatLog.finalizeAnswer(formatted);
           tui.requestRender();
 
-          // If the command has an async follow-up (e.g., backtest), run it with the spinner still active
+          // If the command has an async follow-up (e.g., backtest), animate the spinner while it runs
           if (cmdResult.asyncFollowUp) {
+            answerBox.startSpinner(tui);
             try {
               const followUp = await cmdResult.asyncFollowUp();
+              answerBox.stopSpinner();
               chatLog.finalizeAnswer(formatResponse(followUp));
             } catch (err) {
+              answerBox.stopSpinner();
               chatLog.finalizeAnswer(`Error: ${err instanceof Error ? err.message : String(err)}`);
             }
           }

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -163,8 +163,10 @@ export async function handleAnalyze(
   const edgeComputer = new EdgeComputer(db, auditTrail);
 
   // Use cache by default; only refresh when explicitly requested
+  // Try prefetch first to avoid an individual Octagon API call
   let variant: 'cache' | 'refresh' = refresh ? 'refresh' : 'cache';
-  let report = await octagonClient.fetchReport(resolvedTicker, eventTicker, variant);
+  let report = (!refresh ? octagonClient.tryFromPrefetch(resolvedTicker, eventTicker) : null)
+    ?? await octagonClient.fetchReport(resolvedTicker, eventTicker, variant);
 
   // If cache returned no meaningful data, auto-fetch fresh
   let usedFresh = refresh;

--- a/src/commands/backtest.ts
+++ b/src/commands/backtest.ts
@@ -3,10 +3,26 @@ import type { CLIResponse } from './json.js';
 import { wrapSuccess, wrapError } from './json.js';
 import { getDb } from '../db/index.js';
 import { discoverSettledMarkets, discoverOpenMarkets } from '../backtest/discovery.js';
-import { fetchAndCacheHistory, selectSnapshot } from '../backtest/fetcher.js';
+import { fetchAndCacheHistory, selectSnapshot, type OutcomeProbability } from '../backtest/fetcher.js';
 import { computeResolvedMetrics } from '../backtest/metrics.js';
 import type { BacktestResult, ResolvedMarket, UnresolvedEdge } from '../backtest/types.js';
 import { formatBacktestHuman, exportCSV, type FormatOpts } from '../backtest/renderer.js';
+
+/** Look up per-market model/market probability from outcome_probabilities array. */
+function findOutcomeProb(
+  outcomes: OutcomeProbability[] | null | undefined,
+  marketTicker: string,
+): { modelProb: number; marketProb: number } | null {
+  if (!outcomes || !Array.isArray(outcomes)) return null;
+  const match = outcomes.find(
+    o => o.market_ticker.toUpperCase() === marketTicker.toUpperCase(),
+  );
+  if (!match) return null;
+  return {
+    modelProb: match.model_probability / 100,
+    marketProb: match.market_probability / 100,
+  };
+}
 
 export { formatBacktestHuman };
 export type { FormatOpts };
@@ -56,6 +72,11 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
             const snap = selectSnapshot(snapshots, m.close_time, minHours);
             if (!snap) continue;
 
+            // Use per-market probability from outcome_probabilities if available
+            const perMarket = findOutcomeProb(snap.outcome_probabilities, m.ticker);
+            const modelProb = perMarket?.modelProb ?? snap.model_probability / 100;
+            const marketProb = perMarket?.marketProb ?? snap.market_probability / 100;
+
             const closeEpoch = new Date(m.close_time).getTime();
             const snapEpoch = new Date(snap.captured_at).getTime();
             const hoursBefore = (closeEpoch - snapEpoch) / (3600 * 1000);
@@ -63,9 +84,9 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
             resolvedMarkets.push({
               ticker: m.ticker,
               event_ticker: m.event_ticker,
-              model_prob: snap.model_probability / 100,
-              market_prob: snap.market_probability / 100,
-              edge_pp: Math.round((snap.model_probability - snap.market_probability) * 10) / 10,
+              model_prob: modelProb,
+              market_prob: marketProb,
+              edge_pp: Math.round((modelProb - marketProb) * 1000) / 10,
               hours_before_close: hoursBefore,
               confidence_score: snap.confidence_score ?? 0,
               series_category: m.series_category,
@@ -95,14 +116,20 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
 
     const edges: UnresolvedEdge[] = [];
     for (const m of openMarkets) {
-      // Get latest Octagon model_prob from local cache
+      // Get latest Octagon report from local cache
       const report = db.query(
-        "SELECT model_prob, market_prob, confidence_score FROM octagon_reports WHERE event_ticker = $et AND variant_used = 'events-api' ORDER BY fetched_at DESC LIMIT 1",
-      ).get({ $et: m.event_ticker }) as { model_prob: number; market_prob: number | null; confidence_score: number | null } | null;
+        "SELECT model_prob, market_prob, confidence_score, outcome_probabilities_json FROM octagon_reports WHERE event_ticker = $et AND variant_used = 'events-api' ORDER BY fetched_at DESC LIMIT 1",
+      ).get({ $et: m.event_ticker }) as { model_prob: number; market_prob: number | null; confidence_score: number | null; outcome_probabilities_json: string | null } | null;
 
       if (!report) continue;
 
-      const modelProb = report.model_prob;
+      // Use per-market probability from outcome_probabilities if available
+      let outcomes: OutcomeProbability[] | null = null;
+      if (report.outcome_probabilities_json) {
+        try { outcomes = JSON.parse(report.outcome_probabilities_json); } catch { /* skip */ }
+      }
+      const perMarket = findOutcomeProb(outcomes, m.ticker);
+      const modelProb = perMarket?.modelProb ?? report.model_prob;
       const edgePp = Math.round((modelProb - m.market_prob) * 1000) / 10;
 
       if (Math.abs(edgePp) < minEdge * 100) continue;

--- a/src/commands/backtest.ts
+++ b/src/commands/backtest.ts
@@ -97,8 +97,8 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
     for (const m of openMarkets) {
       // Get latest Octagon model_prob from local cache
       const report = db.query(
-        "SELECT model_prob, market_prob FROM octagon_reports WHERE event_ticker = $et AND variant_used = 'events-api' ORDER BY fetched_at DESC LIMIT 1",
-      ).get({ $et: m.event_ticker }) as { model_prob: number; market_prob: number | null } | null;
+        "SELECT model_prob, market_prob, confidence_score FROM octagon_reports WHERE event_ticker = $et AND variant_used = 'events-api' ORDER BY fetched_at DESC LIMIT 1",
+      ).get({ $et: m.event_ticker }) as { model_prob: number; market_prob: number | null; confidence_score: number | null } | null;
 
       if (!report) continue;
 
@@ -114,7 +114,7 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
         market_prob: m.market_prob,
         edge_pp: edgePp,
         direction: edgePp > 0 ? 'YES' : 'NO',
-        confidence_score: 0, // events API confidence_score not persisted in octagon_reports
+        confidence_score: report.confidence_score ?? 0,
         closes_at: m.close_time,
         series_category: m.series_category,
       });

--- a/src/commands/backtest.ts
+++ b/src/commands/backtest.ts
@@ -68,7 +68,7 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
               market_prob: snap.market_probability / 100,
               edge_pp: (snap.model_probability - snap.market_probability),
               hours_before_close: hoursBefore,
-              confidence_score: snap.confidence_score,
+              confidence_score: snap.confidence_score ?? 0,
               series_category: m.series_category,
               outcome: m.result === 'yes' ? 1 : 0,
               close_time: m.close_time,

--- a/src/commands/backtest.ts
+++ b/src/commands/backtest.ts
@@ -104,7 +104,7 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
   }
 
   // ─── UNRESOLVED: open markets with current Kalshi prices ───────────────
-  if (!args.resolved && !subscriptionNotice) {
+  if (!args.resolved) {
     const openMarkets = await discoverOpenMarkets(db, { category: args.category });
 
     for (const m of openMarkets) {

--- a/src/commands/backtest.ts
+++ b/src/commands/backtest.ts
@@ -6,15 +6,16 @@ import { discoverSettledMarkets, discoverOpenMarkets } from '../backtest/discove
 import { fetchAndCacheHistory, selectSnapshot } from '../backtest/fetcher.js';
 import { computeResolvedMetrics } from '../backtest/metrics.js';
 import type { BacktestResult, ResolvedMarket, UnresolvedEdge } from '../backtest/types.js';
-import { formatBacktestHuman, exportCSV } from '../backtest/renderer.js';
+import { formatBacktestHuman, exportCSV, type FormatOpts } from '../backtest/renderer.js';
 import { logger } from '../utils/logger.js';
 
 export { formatBacktestHuman };
+export type { FormatOpts };
 
 export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<BacktestResult>> {
   const db = getDb();
   const minEdge = args.minEdge ?? 0.05;
-  const minHours = args.minHoursBeforeClose ?? 24;
+  const minHours = args.snapshotLast ? 0 : (args.minHoursBeforeClose ?? 24);
   const now = new Date();
 
   const dateRange = {

--- a/src/commands/backtest.ts
+++ b/src/commands/backtest.ts
@@ -3,7 +3,7 @@ import type { CLIResponse } from './json.js';
 import { wrapSuccess, wrapError } from './json.js';
 import { getDb } from '../db/index.js';
 import { discoverSettledMarkets, discoverOpenMarkets } from '../backtest/discovery.js';
-import { fetchAndCacheHistory, selectSnapshot, type OutcomeProbability } from '../backtest/fetcher.js';
+import { fetchAndCacheHistory, selectSnapshot, SubscriptionRequiredError, type OutcomeProbability } from '../backtest/fetcher.js';
 import { computeResolvedMetrics } from '../backtest/metrics.js';
 import type { BacktestResult, ResolvedMarket, UnresolvedEdge } from '../backtest/types.js';
 import { formatBacktestHuman, exportCSV, type FormatOpts } from '../backtest/renderer.js';
@@ -41,70 +41,77 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
   let resolvedResult: BacktestResult['resolved'] = null;
   let unresolvedResult: BacktestResult['unresolved'] = null;
 
+  let subscriptionNotice: string | undefined;
+
   // ─── RESOLVED ──────────────────────────────────────────────────────────
   if (!args.unresolved) {
+    try {
+      const settled = await discoverSettledMarkets(db, {
+        category: args.category,
+        from: dateRange.from,
+        to: dateRange.to,
+      });
 
-    const settled = await discoverSettledMarkets(db, {
-      category: args.category,
-      from: dateRange.from,
-      to: dateRange.to,
-    });
+      if (settled.length > 0) {
+        const resolvedMarkets: ResolvedMarket[] = [];
 
-    if (settled.length > 0) {
-
-      const resolvedMarkets: ResolvedMarket[] = [];
-
-      // Group by event_ticker to batch history fetches
-      const byEvent = new Map<string, typeof settled>();
-      for (const m of settled) {
-        const arr = byEvent.get(m.event_ticker) ?? [];
-        arr.push(m);
-        byEvent.set(m.event_ticker, arr);
-      }
-
-      for (const [eventTicker, markets] of byEvent) {
-        // Fetch full history (no capturedTo) so the cache is used on repeat runs
-        let snapshots;
-        try {
-          snapshots = await fetchAndCacheHistory(db, eventTicker);
-        } catch {
-          continue; // History fetch failed — skip this event
+        // Group by event_ticker to batch history fetches
+        const byEvent = new Map<string, typeof settled>();
+        for (const m of settled) {
+          const arr = byEvent.get(m.event_ticker) ?? [];
+          arr.push(m);
+          byEvent.set(m.event_ticker, arr);
         }
 
-        for (const m of markets) {
-          const snap = selectSnapshot(snapshots, m.close_time, minHours);
-          if (!snap) continue;
+        for (const [eventTicker, markets] of byEvent) {
+          let snapshots;
+          try {
+            snapshots = await fetchAndCacheHistory(db, eventTicker);
+          } catch (err) {
+            if (err instanceof SubscriptionRequiredError) throw err;
+            continue;
+          }
 
-          // Use per-market probability from outcome_probabilities if available
-          const perMarket = findOutcomeProb(snap.outcome_probabilities, m.ticker);
-          const modelProb = perMarket?.modelProb ?? snap.model_probability / 100;
-          const marketProb = perMarket?.marketProb ?? snap.market_probability / 100;
+          for (const m of markets) {
+            const snap = selectSnapshot(snapshots, m.close_time, minHours);
+            if (!snap) continue;
 
-          const closeEpoch = new Date(m.close_time).getTime();
-          const snapEpoch = new Date(snap.captured_at).getTime();
-          const hoursBefore = (closeEpoch - snapEpoch) / (3600 * 1000);
+            const perMarket = findOutcomeProb(snap.outcome_probabilities, m.ticker);
+            const modelProb = perMarket?.modelProb ?? snap.model_probability / 100;
+            const marketProb = perMarket?.marketProb ?? snap.market_probability / 100;
 
-          resolvedMarkets.push({
-            ticker: m.ticker,
-            event_ticker: m.event_ticker,
-            model_prob: modelProb,
-            market_prob: marketProb,
-            edge_pp: Math.round((modelProb - marketProb) * 1000) / 10,
-            hours_before_close: hoursBefore,
-            confidence_score: snap.confidence_score ?? 0,
-            series_category: m.series_category,
-            outcome: m.result === 'yes' ? 1 : 0,
-            close_time: m.close_time,
-          });
+            const closeEpoch = new Date(m.close_time).getTime();
+            const snapEpoch = new Date(snap.captured_at).getTime();
+            const hoursBefore = (closeEpoch - snapEpoch) / (3600 * 1000);
+
+            resolvedMarkets.push({
+              ticker: m.ticker,
+              event_ticker: m.event_ticker,
+              model_prob: modelProb,
+              market_prob: marketProb,
+              edge_pp: Math.round((modelProb - marketProb) * 1000) / 10,
+              hours_before_close: hoursBefore,
+              confidence_score: snap.confidence_score ?? 0,
+              series_category: m.series_category,
+              outcome: m.result === 'yes' ? 1 : 0,
+              close_time: m.close_time,
+            });
+          }
+        }
+
+        if (resolvedMarkets.length > 0) {
+          const minEdgePp = minEdge * 100;
+          resolvedResult = computeResolvedMetrics(resolvedMarkets, minEdgePp);
+          resolvedResult.coverage = settled.length > 0
+            ? resolvedMarkets.length / settled.length
+            : 0;
         }
       }
-
-      if (resolvedMarkets.length > 0) {
-        const minEdgePp = minEdge * 100;
-        resolvedResult = computeResolvedMetrics(resolvedMarkets, minEdgePp);
-        resolvedResult.coverage = settled.length > 0
-          ? resolvedMarkets.length / settled.length
-          : 0;
+    } catch (err) {
+      if (err instanceof SubscriptionRequiredError) {
+        subscriptionNotice = err.message;
+      } else {
+        throw err;
       }
     }
   }
@@ -161,6 +168,7 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
     resolved: resolvedResult,
     unresolved: unresolvedResult,
     date_range: dateRange,
+    subscription_notice: subscriptionNotice,
   };
 
   // Export CSV if requested

--- a/src/commands/backtest.ts
+++ b/src/commands/backtest.ts
@@ -63,39 +63,39 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
       }
 
       for (const [eventTicker, markets] of byEvent) {
+        // Fetch full history (no capturedTo) so the cache is used on repeat runs
+        let snapshots;
         try {
-          const snapshots = await fetchAndCacheHistory(db, eventTicker, {
-            capturedTo: markets[0].close_time,
+          snapshots = await fetchAndCacheHistory(db, eventTicker);
+        } catch {
+          continue; // History fetch failed — skip this event
+        }
+
+        for (const m of markets) {
+          const snap = selectSnapshot(snapshots, m.close_time, minHours);
+          if (!snap) continue;
+
+          // Use per-market probability from outcome_probabilities if available
+          const perMarket = findOutcomeProb(snap.outcome_probabilities, m.ticker);
+          const modelProb = perMarket?.modelProb ?? snap.model_probability / 100;
+          const marketProb = perMarket?.marketProb ?? snap.market_probability / 100;
+
+          const closeEpoch = new Date(m.close_time).getTime();
+          const snapEpoch = new Date(snap.captured_at).getTime();
+          const hoursBefore = (closeEpoch - snapEpoch) / (3600 * 1000);
+
+          resolvedMarkets.push({
+            ticker: m.ticker,
+            event_ticker: m.event_ticker,
+            model_prob: modelProb,
+            market_prob: marketProb,
+            edge_pp: Math.round((modelProb - marketProb) * 1000) / 10,
+            hours_before_close: hoursBefore,
+            confidence_score: snap.confidence_score ?? 0,
+            series_category: m.series_category,
+            outcome: m.result === 'yes' ? 1 : 0,
+            close_time: m.close_time,
           });
-
-          for (const m of markets) {
-            const snap = selectSnapshot(snapshots, m.close_time, minHours);
-            if (!snap) continue;
-
-            // Use per-market probability from outcome_probabilities if available
-            const perMarket = findOutcomeProb(snap.outcome_probabilities, m.ticker);
-            const modelProb = perMarket?.modelProb ?? snap.model_probability / 100;
-            const marketProb = perMarket?.marketProb ?? snap.market_probability / 100;
-
-            const closeEpoch = new Date(m.close_time).getTime();
-            const snapEpoch = new Date(snap.captured_at).getTime();
-            const hoursBefore = (closeEpoch - snapEpoch) / (3600 * 1000);
-
-            resolvedMarkets.push({
-              ticker: m.ticker,
-              event_ticker: m.event_ticker,
-              model_prob: modelProb,
-              market_prob: marketProb,
-              edge_pp: Math.round((modelProb - marketProb) * 1000) / 10,
-              hours_before_close: hoursBefore,
-              confidence_score: snap.confidence_score ?? 0,
-              series_category: m.series_category,
-              outcome: m.result === 'yes' ? 1 : 0,
-              close_time: m.close_time,
-            });
-          }
-        } catch (err) {
-          // History fetch failed for this event — skip
         }
       }
 

--- a/src/commands/backtest.ts
+++ b/src/commands/backtest.ts
@@ -1,0 +1,146 @@
+import type { ParsedArgs } from './parse-args.js';
+import type { CLIResponse } from './json.js';
+import { wrapSuccess, wrapError } from './json.js';
+import { getDb } from '../db/index.js';
+import { discoverSettledMarkets, discoverOpenMarkets } from '../backtest/discovery.js';
+import { fetchAndCacheHistory, selectSnapshot } from '../backtest/fetcher.js';
+import { computeResolvedMetrics } from '../backtest/metrics.js';
+import type { BacktestResult, ResolvedMarket, UnresolvedEdge } from '../backtest/types.js';
+import { formatBacktestHuman, exportCSV } from '../backtest/renderer.js';
+import { logger } from '../utils/logger.js';
+
+export { formatBacktestHuman };
+
+export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<BacktestResult>> {
+  const db = getDb();
+  const minEdge = args.minEdge ?? 0.05;
+  const minHours = args.minHoursBeforeClose ?? 24;
+  const now = new Date();
+
+  const dateRange = {
+    from: args.from ?? '2025-01-01',
+    to: args.to ?? now.toISOString().slice(0, 10),
+  };
+
+  let resolvedResult: BacktestResult['resolved'] = null;
+  let unresolvedResult: BacktestResult['unresolved'] = null;
+
+  // ─── RESOLVED ──────────────────────────────────────────────────────────
+  if (!args.unresolved) {
+    logger.info('[backtest] Discovering settled markets with Octagon coverage...');
+    const settled = await discoverSettledMarkets(db, {
+      category: args.category,
+      from: dateRange.from,
+      to: dateRange.to,
+    });
+
+    if (settled.length > 0) {
+      logger.info(`[backtest] Fetching Octagon history for ${settled.length} settled markets...`);
+      const resolvedMarkets: ResolvedMarket[] = [];
+
+      // Group by event_ticker to batch history fetches
+      const byEvent = new Map<string, typeof settled>();
+      for (const m of settled) {
+        const arr = byEvent.get(m.event_ticker) ?? [];
+        arr.push(m);
+        byEvent.set(m.event_ticker, arr);
+      }
+
+      for (const [eventTicker, markets] of byEvent) {
+        try {
+          const snapshots = await fetchAndCacheHistory(db, eventTicker, {
+            capturedTo: markets[0].close_time,
+          });
+
+          for (const m of markets) {
+            const snap = selectSnapshot(snapshots, m.close_time, minHours);
+            if (!snap) continue;
+
+            const closeEpoch = new Date(m.close_time).getTime();
+            const snapEpoch = new Date(snap.captured_at).getTime();
+            const hoursBefore = (closeEpoch - snapEpoch) / (3600 * 1000);
+
+            resolvedMarkets.push({
+              ticker: m.ticker,
+              event_ticker: m.event_ticker,
+              model_prob: snap.model_probability / 100,
+              market_prob: snap.market_probability / 100,
+              edge_pp: (snap.model_probability - snap.market_probability),
+              hours_before_close: hoursBefore,
+              confidence_score: snap.confidence_score,
+              series_category: m.series_category,
+              outcome: m.result === 'yes' ? 1 : 0,
+              close_time: m.close_time,
+            });
+          }
+        } catch (err) {
+          logger.warn(`[backtest] Failed history for ${eventTicker}: ${err instanceof Error ? err.message : err}`);
+        }
+      }
+
+      if (resolvedMarkets.length > 0) {
+        const minEdgePp = minEdge * 100;
+        resolvedResult = computeResolvedMetrics(resolvedMarkets, minEdgePp);
+        resolvedResult.coverage = settled.length > 0
+          ? resolvedMarkets.length / settled.length
+          : 0;
+      }
+    }
+  }
+
+  // ─── UNRESOLVED ────────────────────────────────────────────────────────
+  if (!args.resolved) {
+    logger.info('[backtest] Discovering open markets with Octagon coverage...');
+    const openMarkets = await discoverOpenMarkets(db, { category: args.category });
+
+    const edges: UnresolvedEdge[] = [];
+    for (const m of openMarkets) {
+      // Get latest Octagon model_prob from local cache
+      const report = db.query(
+        "SELECT model_prob FROM octagon_reports WHERE event_ticker = $et AND variant_used = 'events-api' ORDER BY fetched_at DESC LIMIT 1",
+      ).get({ $et: m.event_ticker }) as { model_prob: number } | null;
+
+      if (!report) continue;
+
+      const modelProb = report.model_prob;
+      const edgePp = (modelProb - m.market_prob) * 100;
+
+      if (Math.abs(edgePp) < minEdge * 100) continue;
+
+      edges.push({
+        ticker: m.ticker,
+        event_ticker: m.event_ticker,
+        model_prob: modelProb,
+        market_prob: m.market_prob,
+        edge_pp: edgePp,
+        direction: edgePp > 0 ? 'YES' : 'NO',
+        confidence_score: 0,
+        closes_at: m.close_time,
+        series_category: m.series_category,
+      });
+    }
+
+    // Sort by |edge| descending
+    edges.sort((a, b) => Math.abs(b.edge_pp) - Math.abs(a.edge_pp));
+
+    unresolvedResult = {
+      edges,
+      total_open_with_coverage: openMarkets.length,
+      total_open: openMarkets.length,
+    };
+  }
+
+  const result: BacktestResult = {
+    resolved: resolvedResult,
+    unresolved: unresolvedResult,
+    date_range: dateRange,
+  };
+
+  // Export CSV if requested
+  if (args.exportPath) {
+    exportCSV(result, args.exportPath);
+    logger.info(`[backtest] Exported results to ${args.exportPath}`);
+  }
+
+  return wrapSuccess('backtest', result);
+}

--- a/src/commands/backtest.ts
+++ b/src/commands/backtest.ts
@@ -1,14 +1,14 @@
 import type { ParsedArgs } from './parse-args.js';
 import type { CLIResponse } from './json.js';
-import { wrapSuccess, wrapError } from './json.js';
+import { wrapSuccess } from './json.js';
 import { getDb } from '../db/index.js';
 import { discoverSettledMarkets, discoverOpenMarkets } from '../backtest/discovery.js';
-import { fetchAndCacheHistory, selectSnapshot, SubscriptionRequiredError, type OutcomeProbability } from '../backtest/fetcher.js';
-import { computeResolvedMetrics } from '../backtest/metrics.js';
-import type { BacktestResult, ResolvedMarket, UnresolvedEdge } from '../backtest/types.js';
+import { fetchAndCacheHistory, selectSnapshotByDate, SubscriptionRequiredError, type OutcomeProbability } from '../backtest/fetcher.js';
+import { computeMetrics } from '../backtest/metrics.js';
+import type { BacktestResult, ScoredSignal } from '../backtest/types.js';
 import { formatBacktestHuman, exportCSV, type FormatOpts } from '../backtest/renderer.js';
 
-/** Look up per-market model/market probability from outcome_probabilities array. */
+/** Look up per-market model/market probability from outcome_probabilities array (0-100 scale). */
 function findOutcomeProb(
   outcomes: OutcomeProbability[] | null | undefined,
   marketTicker: string,
@@ -18,10 +18,7 @@ function findOutcomeProb(
     o => o.market_ticker.toUpperCase() === marketTicker.toUpperCase(),
   );
   if (!match) return null;
-  return {
-    modelProb: match.model_probability / 100,
-    marketProb: match.market_probability / 100,
-  };
+  return { modelProb: match.model_probability, marketProb: match.market_probability };
 }
 
 export { formatBacktestHuman };
@@ -29,32 +26,21 @@ export type { FormatOpts };
 
 export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<BacktestResult>> {
   const db = getDb();
+  const days = args.days ?? 30;
   const minEdge = args.minEdge ?? 0.05;
-  const minHours = args.snapshotLast ? 0 : (args.minHoursBeforeClose ?? 24);
+  const minEdgePp = minEdge * 100;
   const now = new Date();
+  const lookbackDate = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
 
-  const dateRange = {
-    from: args.from ?? '2025-01-01',
-    to: args.to ?? now.toISOString().slice(0, 10),
-  };
-
-  let resolvedResult: BacktestResult['resolved'] = null;
-  let unresolvedResult: BacktestResult['unresolved'] = null;
-
+  const signals: ScoredSignal[] = [];
   let subscriptionNotice: string | undefined;
 
-  // ─── RESOLVED ──────────────────────────────────────────────────────────
+  // ─── RESOLVED: settled markets with historical Octagon snapshots ────────
   if (!args.unresolved) {
     try {
-      const settled = await discoverSettledMarkets(db, {
-        category: args.category,
-        from: dateRange.from,
-        to: dateRange.to,
-      });
+      const settled = await discoverSettledMarkets(db, { category: args.category });
 
       if (settled.length > 0) {
-        const resolvedMarkets: ResolvedMarket[] = [];
-
         // Group by event_ticker to batch history fetches
         const byEvent = new Map<string, typeof settled>();
         for (const m of settled) {
@@ -72,39 +58,40 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
             continue;
           }
 
+          // Find the snapshot closest to N days ago
+          const snap = selectSnapshotByDate(snapshots, lookbackDate);
+          if (!snap) continue;
+
           for (const m of markets) {
-            const snap = selectSnapshot(snapshots, m.close_time, minHours);
-            if (!snap) continue;
-
+            // Per-market probability from outcome_probabilities (0-100 scale)
             const perMarket = findOutcomeProb(snap.outcome_probabilities, m.ticker);
-            const modelProb = perMarket?.modelProb ?? snap.model_probability / 100;
-            const marketProb = perMarket?.marketProb ?? snap.market_probability / 100;
+            const modelProb = perMarket?.modelProb ?? snap.model_probability;
+            const marketThen = perMarket?.marketProb ?? snap.market_probability;
+            const marketNow = m.result === 'yes' ? 100 : 0;
+            const edgePp = Math.round((modelProb - marketThen) * 10) / 10;
 
-            const closeEpoch = new Date(m.close_time).getTime();
-            const snapEpoch = new Date(snap.captured_at).getTime();
-            const hoursBefore = (closeEpoch - snapEpoch) / (3600 * 1000);
+            // P&L: Buy YES if edge > 0, Buy NO if edge < 0
+            let pnl = 0;
+            if (edgePp > 0) {
+              pnl = (marketNow - marketThen) / 100;  // bought YES at marketThen, settled at marketNow
+            } else if (edgePp < 0) {
+              pnl = (marketThen - marketNow) / 100;  // bought NO at (100-marketThen), settled at (100-marketNow)
+            }
 
-            resolvedMarkets.push({
-              ticker: m.ticker,
+            signals.push({
               event_ticker: m.event_ticker,
-              model_prob: modelProb,
-              market_prob: marketProb,
-              edge_pp: Math.round((modelProb - marketProb) * 1000) / 10,
-              hours_before_close: hoursBefore,
-              confidence_score: snap.confidence_score ?? 0,
+              market_ticker: m.ticker,
               series_category: m.series_category,
-              outcome: m.result === 'yes' ? 1 : 0,
+              model_prob: modelProb,
+              market_then: marketThen,
+              market_now: marketNow,
+              resolved: true,
+              edge_pp: edgePp,
+              pnl: Math.round(pnl * 100) / 100,
+              confidence_score: snap.confidence_score ?? 0,
               close_time: m.close_time,
             });
           }
-        }
-
-        if (resolvedMarkets.length > 0) {
-          const minEdgePp = minEdge * 100;
-          resolvedResult = computeResolvedMetrics(resolvedMarkets, minEdgePp);
-          resolvedResult.coverage = settled.length > 0
-            ? resolvedMarkets.length / settled.length
-            : 0;
         }
       }
     } catch (err) {
@@ -116,65 +103,108 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
     }
   }
 
-  // ─── UNRESOLVED ────────────────────────────────────────────────────────
-  if (!args.resolved) {
-
+  // ─── UNRESOLVED: open markets with current Kalshi prices ───────────────
+  if (!args.resolved && !subscriptionNotice) {
     const openMarkets = await discoverOpenMarkets(db, { category: args.category });
 
-    const edges: UnresolvedEdge[] = [];
     for (const m of openMarkets) {
-      // Get latest Octagon report from local cache
+      // Get Octagon report from local cache
       const report = db.query(
-        "SELECT model_prob, market_prob, confidence_score, outcome_probabilities_json FROM octagon_reports WHERE event_ticker = $et AND variant_used = 'events-api' ORDER BY fetched_at DESC LIMIT 1",
-      ).get({ $et: m.event_ticker }) as { model_prob: number; market_prob: number | null; confidence_score: number | null; outcome_probabilities_json: string | null } | null;
+        "SELECT model_prob, confidence_score, outcome_probabilities_json FROM octagon_reports WHERE event_ticker = $et AND variant_used = 'events-api' ORDER BY fetched_at DESC LIMIT 1",
+      ).get({ $et: m.event_ticker }) as { model_prob: number; confidence_score: number | null; outcome_probabilities_json: string | null } | null;
 
       if (!report) continue;
 
-      // Use per-market probability from outcome_probabilities if available
-      let outcomes: OutcomeProbability[] | null = null;
-      if (report.outcome_probabilities_json) {
-        try { outcomes = JSON.parse(report.outcome_probabilities_json); } catch { /* skip */ }
+      // Try to get historical snapshot from N days ago for market_then
+      // Fall back to the prefetched events API market_probability if no history
+      let modelProb: number;
+      let marketThen: number;
+      let confidenceScore = report.confidence_score ?? 0;
+
+      // Check if we have cached history for this event
+      const historyCount = db.query(
+        'SELECT COUNT(*) as cnt FROM octagon_history WHERE event_ticker = $et',
+      ).get({ $et: m.event_ticker }) as { cnt: number };
+
+      if (historyCount.cnt > 0) {
+        // Use historical snapshot from N days ago
+        const rows = db.query(
+          `SELECT model_probability, market_probability, confidence_score, outcome_probabilities_json
+           FROM octagon_history WHERE event_ticker = $et AND captured_at <= $cutoff
+           ORDER BY captured_at DESC LIMIT 1`,
+        ).get({ $et: m.event_ticker, $cutoff: lookbackDate.toISOString() }) as {
+          model_probability: number; market_probability: number;
+          confidence_score: number | null; outcome_probabilities_json: string | null;
+        } | null;
+
+        if (rows) {
+          let outcomes: OutcomeProbability[] | null = null;
+          if (rows.outcome_probabilities_json) {
+            try { outcomes = JSON.parse(rows.outcome_probabilities_json); } catch { /* skip */ }
+          }
+          const perMarket = findOutcomeProb(outcomes, m.ticker);
+          modelProb = perMarket?.modelProb ?? rows.model_probability;
+          marketThen = perMarket?.marketProb ?? rows.market_probability;
+          confidenceScore = rows.confidence_score ?? confidenceScore;
+        } else {
+          // No snapshot old enough — use current prefetched data
+          let outcomes: OutcomeProbability[] | null = null;
+          if (report.outcome_probabilities_json) {
+            try { outcomes = JSON.parse(report.outcome_probabilities_json); } catch { /* skip */ }
+          }
+          const perMarket = findOutcomeProb(outcomes, m.ticker);
+          modelProb = perMarket ? perMarket.modelProb : report.model_prob * 100;
+          marketThen = perMarket ? perMarket.marketProb : m.market_prob * 100;
+        }
+      } else {
+        // No history — use current prefetched data as both model and market_then
+        let outcomes: OutcomeProbability[] | null = null;
+        if (report.outcome_probabilities_json) {
+          try { outcomes = JSON.parse(report.outcome_probabilities_json); } catch { /* skip */ }
+        }
+        const perMarket = findOutcomeProb(outcomes, m.ticker);
+        modelProb = perMarket ? perMarket.modelProb : report.model_prob * 100;
+        marketThen = perMarket ? perMarket.marketProb : m.market_prob * 100;
       }
-      const perMarket = findOutcomeProb(outcomes, m.ticker);
-      const modelProb = perMarket?.modelProb ?? report.model_prob;
-      const edgePp = Math.round((modelProb - m.market_prob) * 1000) / 10;
 
-      if (Math.abs(edgePp) < minEdge * 100) continue;
+      const marketNow = m.market_prob * 100; // current Kalshi price (0-100)
+      const edgePp = Math.round((modelProb - marketThen) * 10) / 10;
 
-      edges.push({
-        ticker: m.ticker,
+      // M2M P&L
+      let pnl = 0;
+      if (edgePp > 0) {
+        pnl = (marketNow - marketThen) / 100;
+      } else if (edgePp < 0) {
+        pnl = (marketThen - marketNow) / 100;
+      }
+
+      signals.push({
         event_ticker: m.event_ticker,
-        model_prob: modelProb,
-        market_prob: m.market_prob,
-        edge_pp: edgePp,
-        direction: edgePp > 0 ? 'YES' : 'NO',
-        confidence_score: report.confidence_score ?? 0,
-        closes_at: m.close_time,
+        market_ticker: m.ticker,
         series_category: m.series_category,
+        model_prob: modelProb,
+        market_then: marketThen,
+        market_now: marketNow,
+        resolved: false,
+        edge_pp: edgePp,
+        pnl: Math.round(pnl * 100) / 100,
+        confidence_score: confidenceScore,
+        close_time: m.close_time,
       });
     }
-
-    // Sort by |edge| descending
-    edges.sort((a, b) => Math.abs(b.edge_pp) - Math.abs(a.edge_pp));
-
-    unresolvedResult = {
-      edges,
-      total_open_with_coverage: openMarkets.length,
-      total_open: openMarkets.length,
-    };
   }
 
+  // ─── COMPUTE METRICS ───────────────────────────────────────────────────
+  const metrics = computeMetrics(signals, minEdgePp);
+
   const result: BacktestResult = {
-    resolved: resolvedResult,
-    unresolved: unresolvedResult,
-    date_range: dateRange,
+    ...metrics,
+    days,
     subscription_notice: subscriptionNotice,
   };
 
-  // Export CSV if requested
   if (args.exportPath) {
     exportCSV(result, args.exportPath);
-
   }
 
   return wrapSuccess('backtest', result);

--- a/src/commands/backtest.ts
+++ b/src/commands/backtest.ts
@@ -65,7 +65,7 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
               event_ticker: m.event_ticker,
               model_prob: snap.model_probability / 100,
               market_prob: snap.market_probability / 100,
-              edge_pp: (snap.model_probability - snap.market_probability),
+              edge_pp: Math.round((snap.model_probability - snap.market_probability) * 10) / 10,
               hours_before_close: hoursBefore,
               confidence_score: snap.confidence_score ?? 0,
               series_category: m.series_category,
@@ -97,13 +97,13 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
     for (const m of openMarkets) {
       // Get latest Octagon model_prob from local cache
       const report = db.query(
-        "SELECT model_prob FROM octagon_reports WHERE event_ticker = $et AND variant_used = 'events-api' ORDER BY fetched_at DESC LIMIT 1",
-      ).get({ $et: m.event_ticker }) as { model_prob: number } | null;
+        "SELECT model_prob, market_prob FROM octagon_reports WHERE event_ticker = $et AND variant_used = 'events-api' ORDER BY fetched_at DESC LIMIT 1",
+      ).get({ $et: m.event_ticker }) as { model_prob: number; market_prob: number | null } | null;
 
       if (!report) continue;
 
       const modelProb = report.model_prob;
-      const edgePp = (modelProb - m.market_prob) * 100;
+      const edgePp = Math.round((modelProb - m.market_prob) * 1000) / 10;
 
       if (Math.abs(edgePp) < minEdge * 100) continue;
 
@@ -114,7 +114,7 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
         market_prob: m.market_prob,
         edge_pp: edgePp,
         direction: edgePp > 0 ? 'YES' : 'NO',
-        confidence_score: 0,
+        confidence_score: 0, // events API confidence_score not persisted in octagon_reports
         closes_at: m.close_time,
         series_category: m.series_category,
       });

--- a/src/commands/backtest.ts
+++ b/src/commands/backtest.ts
@@ -7,7 +7,6 @@ import { fetchAndCacheHistory, selectSnapshot } from '../backtest/fetcher.js';
 import { computeResolvedMetrics } from '../backtest/metrics.js';
 import type { BacktestResult, ResolvedMarket, UnresolvedEdge } from '../backtest/types.js';
 import { formatBacktestHuman, exportCSV, type FormatOpts } from '../backtest/renderer.js';
-import { logger } from '../utils/logger.js';
 
 export { formatBacktestHuman };
 export type { FormatOpts };
@@ -28,7 +27,7 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
 
   // ─── RESOLVED ──────────────────────────────────────────────────────────
   if (!args.unresolved) {
-    logger.info('[backtest] Discovering settled markets with Octagon coverage...');
+
     const settled = await discoverSettledMarkets(db, {
       category: args.category,
       from: dateRange.from,
@@ -36,7 +35,7 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
     });
 
     if (settled.length > 0) {
-      logger.info(`[backtest] Fetching Octagon history for ${settled.length} settled markets...`);
+
       const resolvedMarkets: ResolvedMarket[] = [];
 
       // Group by event_ticker to batch history fetches
@@ -75,7 +74,7 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
             });
           }
         } catch (err) {
-          logger.warn(`[backtest] Failed history for ${eventTicker}: ${err instanceof Error ? err.message : err}`);
+          // History fetch failed for this event — skip
         }
       }
 
@@ -91,7 +90,7 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
 
   // ─── UNRESOLVED ────────────────────────────────────────────────────────
   if (!args.resolved) {
-    logger.info('[backtest] Discovering open markets with Octagon coverage...');
+
     const openMarkets = await discoverOpenMarkets(db, { category: args.category });
 
     const edges: UnresolvedEdge[] = [];
@@ -140,7 +139,7 @@ export async function handleBacktest(args: ParsedArgs): Promise<CLIResponse<Back
   // Export CSV if requested
   if (args.exportPath) {
     exportCSV(result, args.exportPath);
-    logger.info(`[backtest] Exported results to ${args.exportPath}`);
+
   }
 
   return wrapSuccess('backtest', result);

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -22,6 +22,7 @@ import { buildHelp, validateTradeArgs } from './help.js';
 import { fetchMarketQuote } from './helpers.js';
 import { ensureIndex, forceRefreshIndex } from '../tools/kalshi/search-index.js';
 import { searchEventIndex } from '../db/event-index.js';
+import { scanEdges, formatEdgeScanHuman } from './search-edge.js';
 import type { KalshiBalanceResponse } from './formatters.js';
 import { ExitCode, exitCodeFromError } from '../utils/errors.js';
 import { trackEvent } from '../utils/telemetry.js';
@@ -83,6 +84,18 @@ export async function dispatch(args: ParsedArgs): Promise<void> {
           console.log(formatThemesHuman(resp.data));
         }
         process.exit(resp.ok ? ExitCode.SUCCESS : ExitCode.USER_ERROR);
+        return;
+      }
+      if (sub === 'edge') {
+        const db = (await import('../db/index.js')).getDb();
+        const minEdgePp = (args.minEdge ?? 0.05) * 100;
+        const result = scanEdges(db, { minEdgePp, limit: args.limit, category: args.category });
+        if (json) {
+          console.log(JSON.stringify(wrapSuccess('search', result)));
+        } else {
+          console.log(formatEdgeScanHuman(result, minEdgePp));
+        }
+        process.exit(ExitCode.SUCCESS);
         return;
       }
       if (!sub) {

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -239,7 +239,11 @@ export async function dispatch(args: ParsedArgs): Promise<void> {
       if (json) {
         console.log(JSON.stringify(resp));
       } else if (resp.ok && resp.data) {
-        console.log(formatBacktestHuman(resp.data));
+        console.log(formatBacktestHuman(resp.data, {
+          minEdge: args.minEdge ?? 0.05,
+          minHoursBeforeClose: args.minHoursBeforeClose ?? 24,
+          snapshotLast: args.snapshotLast,
+        }));
       } else {
         console.error(resp.error?.message ?? 'Backtest failed');
       }

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -10,6 +10,7 @@ import { handleAlerts, formatAlertsHuman } from './alerts.js';
 import { handleStatus } from './status.js';
 import { handleThemes, formatThemesHuman } from './themes.js';
 import { handleWatch } from './watch.js';
+import { handleBacktest, formatBacktestHuman } from './backtest.js';
 import { callKalshiApi } from '../tools/kalshi/api.js';
 import {
   formatBalance,
@@ -229,6 +230,20 @@ export async function dispatch(args: ParsedArgs): Promise<void> {
       }
       // Theme scan mode (existing behavior)
       await handleWatch(args);
+      return;
+    }
+
+    // ─── backtest ──────────────────────────────────────────────────────
+    if (resolved.canonical === 'backtest') {
+      const resp = await handleBacktest(args);
+      if (json) {
+        console.log(JSON.stringify(resp));
+      } else if (resp.ok && resp.data) {
+        console.log(formatBacktestHuman(resp.data));
+      } else {
+        console.error(resp.error?.message ?? 'Backtest failed');
+      }
+      process.exit(resp.ok ? ExitCode.SUCCESS : ExitCode.USER_ERROR);
       return;
     }
 

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -241,8 +241,6 @@ export async function dispatch(args: ParsedArgs): Promise<void> {
       } else if (resp.ok && resp.data) {
         console.log(formatBacktestHuman(resp.data, {
           minEdge: args.minEdge ?? 0.05,
-          minHoursBeforeClose: args.minHoursBeforeClose ?? 24,
-          snapshotLast: args.snapshotLast,
         }));
       } else {
         console.error(resp.error?.message ?? 'Backtest failed');

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -14,11 +14,16 @@ function buildTopics(ctx: HelpContext): Record<string, string> {
 
 ${p}search [theme|ticker|query]  Search events by theme, ticker, or free-text
 ${p}search themes                List all available themes and subcategories
+${p}search edge                  Scan all markets by Octagon model edge
+${p}search edge --min-edge 30    Markets with ≥30pp edge
+${p}search edge --limit 50       Top 50 results
+${p}search edge --category crypto Filter by category
 
 Examples:
   ${p}search crypto
   ${p}search crypto:btc
-  ${p}search "bitcoin price"`,
+  ${p}search "bitcoin price"
+  ${p}search edge --min-edge 30 --category crypto`,
 
     portfolio: `**${p}portfolio** — Account state
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -120,7 +120,7 @@ ${p}help <command>             Show detailed help for a command`,
 function buildOverview(ctx: HelpContext): string {
   const p = prefix(ctx);
   if (ctx === 'cli') {
-    return `**Kalshi Deep Trading Bot — CLI Commands**
+    return `**Kalshi Trading Bot CLI — CLI Commands**
 
 Quick start:
   kalshi search crypto          Find markets by keyword or theme
@@ -164,7 +164,7 @@ Backtest flags: --resolved, --unresolved, --category, --from, --to, --min-edge, 
 Run "kalshi help <command>" for detailed usage.`;
   }
 
-  return `**Kalshi Deep Trading Bot — Commands**
+  return `**Kalshi Trading Bot CLI — Commands**
 
 Quick start:
   /search crypto          Find markets by keyword or theme

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -81,22 +81,20 @@ Side defaults to YES if omitted.`,
 
 ${p}cancel <order_id>`,
 
-    backtest: `**${p}backtest** — Model accuracy scorecard & live edge scanner
+    backtest: `**${p}backtest** — Model accuracy scorecard & edge scanner
 
-${p}backtest                              Both resolved + unresolved (default)
-${p}backtest --resolved                   Resolved only (scorecard)
-${p}backtest --unresolved                 Unresolved only (live edge scanner)
+${p}backtest                              30-day lookback, both sections (default)
+${p}backtest --days 60                    60-day lookback
+${p}backtest --resolved                   Resolved markets only
+${p}backtest --unresolved                 Unresolved markets only
 ${p}backtest --category crypto            Filter by category
-${p}backtest --from 2026-01-01 --to 2026-03-31
-${p}backtest --min-hours-before-close 48  Custom lead time (resolved)
 ${p}backtest --min-edge 10                Stricter edge threshold (pp)
-${p}backtest --snapshot last              Use latest snapshot (no lead time)
 ${p}backtest --export results.csv         Per-market detail CSV
 ${p}backtest --json                       Machine-readable output
 
-Resolved: measures Brier accuracy, skill score, edge hit rate, and flat-bet P&L
-on settled markets using Octagon snapshots from ≥24h before close.
-Unresolved: ranks open markets by current model-vs-market edge.`,
+Looks back N days, compares what the model said then to where the market is now.
+Resolved markets: scored against Kalshi settlement (0 or 100).
+Unresolved markets: mark-to-market vs current Kalshi trading price.`,
 
     'clear-cache': `**${ctx === 'cli' ? '' : 'bun start '}clear-cache** — Delete local cache
 
@@ -160,7 +158,7 @@ System:
   help [command]                Show help for a command
 
 Flags: --json, --refresh, --performance, --dry-run, --verbose
-Backtest flags: --resolved, --unresolved, --category, --from, --to, --min-edge, --export
+Backtest flags: --days, --resolved, --unresolved, --category, --min-edge, --export
 Run "kalshi help <command>" for detailed usage.`;
   }
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -81,6 +81,23 @@ Side defaults to YES if omitted.`,
 
 ${p}cancel <order_id>`,
 
+    backtest: `**${p}backtest** — Model accuracy scorecard & live edge scanner
+
+${p}backtest                              Both resolved + unresolved (default)
+${p}backtest --resolved                   Resolved only (scorecard)
+${p}backtest --unresolved                 Unresolved only (live edge scanner)
+${p}backtest --category crypto            Filter by category
+${p}backtest --from 2026-01-01 --to 2026-03-31
+${p}backtest --min-hours-before-close 48  Custom lead time (resolved)
+${p}backtest --min-edge 10                Stricter edge threshold (pp)
+${p}backtest --snapshot last              Use latest snapshot (no lead time)
+${p}backtest --export results.csv         Per-market detail CSV
+${p}backtest --json                       Machine-readable output
+
+Resolved: measures Brier accuracy, skill score, edge hit rate, and flat-bet P&L
+on settled markets using Octagon snapshots from ≥24h before close.
+Unresolved: ranks open markets by current model-vs-market edge.`,
+
     'clear-cache': `**${ctx === 'cli' ? '' : 'bun start '}clear-cache** — Delete local cache
 
 ${ctx === 'cli' ? `${p}` : 'bun start '}clear-cache                Delete the local SQLite database (~/.kalshi-bot/kalshi-bot.db)
@@ -125,6 +142,11 @@ Analysis & Trading:
   sell <ticker> <n> [price] [yes|no]  Sell contracts
   cancel <order_id>                   Cancel a resting order
 
+Analysis:
+  backtest                      Model accuracy scorecard + live edge scanner
+  backtest --resolved           Resolved markets scorecard only
+  backtest --unresolved         Live edge scanner only
+
 Account:
   portfolio                     Overview: positions, P&L, risk snapshot
   portfolio positions           Open positions
@@ -138,6 +160,7 @@ System:
   help [command]                Show help for a command
 
 Flags: --json, --refresh, --performance, --dry-run, --verbose
+Backtest flags: --resolved, --unresolved, --category, --from, --to, --min-edge, --export
 Run "kalshi help <command>" for detailed usage.`;
   }
 
@@ -156,7 +179,8 @@ Discovery:
   /watch --theme <theme>         Continuous theme scan (Esc to stop)
   /watch --refresh               Force index rebuild before watching
 
-Analysis & Trading:
+Analysis:
+  /backtest                      Model accuracy scorecard + live edge scanner
   /analyze <ticker>              Full report: edge, drivers, Kelly sizing
   /analyze <ticker> refresh      Force fresh Octagon report
   /buy <ticker> <n> [price] [yes|no]   Buy contracts (price in cents)

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -68,7 +68,7 @@ export async function handleSlashCommand(input: string): Promise<CommandResult |
     // ─── /search themes (inline) ─────────────────────────────────────
     // Note: /search <non-themes> is handled in cli.ts via browseController
     case 'themes': {
-      const resp = await handleThemes({ subcommand: 'themes', positionalArgs: [], json: false, live: false, refresh: false, report: false, dryRun: false, verbose: false, performance: false, parseErrors: [] });
+      const resp = await handleThemes({ subcommand: 'themes', positionalArgs: [], json: false, live: false, refresh: false, report: false, dryRun: false, verbose: false, performance: false, resolved: false, unresolved: false, snapshotLast: false, parseErrors: [] });
       return { output: formatThemesHuman(resp.data) };
     }
 
@@ -152,7 +152,8 @@ async function handlePortfolioSlash(subview?: string): Promise<CommandResult> {
     // Default: full portfolio overview
     const resp = await handlePortfolio({
       subcommand: 'portfolio', positionalArgs: [], json: false,
-      live: false, refresh: false, report: false, dryRun: false, verbose: false, performance: false, parseErrors: [],
+      live: false, refresh: false, report: false, dryRun: false, verbose: false, performance: false,
+      resolved: false, unresolved: false, snapshotLast: false, parseErrors: [],
     });
     return { output: formatPortfolioHuman(resp.data) };
   } catch (err) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,6 +9,17 @@ import {
   formatOrderConfirmation,
 } from './formatters.js';
 import { handleThemes, formatThemesHuman } from './themes.js';
+import type { ParsedArgs, Subcommand } from './parse-args.js';
+
+function defaultArgs(overrides: Partial<ParsedArgs>): ParsedArgs {
+  return {
+    subcommand: 'chat', positionalArgs: [], json: false,
+    live: false, refresh: false, report: false, dryRun: false,
+    verbose: false, performance: false, resolved: false,
+    unresolved: false, snapshotLast: false, parseErrors: [],
+    ...overrides,
+  };
+}
 import { handleAnalyze, formatAnalyzeHuman } from './analyze.js';
 import { handlePortfolio, formatPortfolioHuman } from './portfolio.js';
 import { reviewPortfolio, formatReviewHuman } from './review.js';
@@ -68,7 +79,7 @@ export async function handleSlashCommand(input: string): Promise<CommandResult |
     // ─── /search themes (inline) ─────────────────────────────────────
     // Note: /search <non-themes> is handled in cli.ts via browseController
     case 'themes': {
-      const resp = await handleThemes({ subcommand: 'themes', positionalArgs: [], json: false, live: false, refresh: false, report: false, dryRun: false, verbose: false, performance: false, resolved: false, unresolved: false, snapshotLast: false, parseErrors: [] });
+      const resp = await handleThemes(defaultArgs({ subcommand: 'themes' }));
       return { output: formatThemesHuman(resp.data) };
     }
 
@@ -150,11 +161,7 @@ async function handlePortfolioSlash(subview?: string): Promise<CommandResult> {
     }
 
     // Default: full portfolio overview
-    const resp = await handlePortfolio({
-      subcommand: 'portfolio', positionalArgs: [], json: false,
-      live: false, refresh: false, report: false, dryRun: false, verbose: false, performance: false,
-      resolved: false, unresolved: false, snapshotLast: false, parseErrors: [],
-    });
+    const resp = await handlePortfolio(defaultArgs({ subcommand: 'portfolio' }));
     return { output: formatPortfolioHuman(resp.data) };
   } catch (err) {
     return { output: `Portfolio error: ${err instanceof Error ? err.message : String(err)}` };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -38,6 +38,8 @@ export interface CommandResult {
     count: number;
     price: number | undefined;
   };
+  /** If set, run this async function after showing `output` and append the result */
+  asyncFollowUp?: () => Promise<string>;
 }
 
 export async function handleSlashCommand(input: string): Promise<CommandResult | null> {
@@ -107,13 +109,21 @@ export async function handleSlashCommand(input: string): Promise<CommandResult |
         else if (a === '--min-hours-before-close') { const v = Number(args[++i]); if (Number.isFinite(v)) btArgs.minHoursBeforeClose = v; }
         else if (a === '--snapshot' && args[i + 1] === 'last') { btArgs.snapshotLast = true; i++; }
       }
-      const resp = await handleBacktest(defaultArgs(btArgs));
-      if (!resp.ok || !resp.data) return { output: resp.error?.message ?? 'Backtest failed' };
-      return { output: formatBacktestHuman(resp.data, {
-        minEdge: btArgs.minEdge ?? 0.05,
-        minHoursBeforeClose: btArgs.minHoursBeforeClose ?? 24,
-        snapshotLast: btArgs.snapshotLast,
-      }) };
+      const mode = btArgs.resolved ? 'resolved markets' : btArgs.unresolved ? 'open markets' : 'resolved + open markets';
+      // Return a progress message immediately, then run the backtest
+      // The caller (cli.ts) will show this while the spinner is active
+      return {
+        output: `Running backtest on ${mode}...`,
+        asyncFollowUp: async () => {
+          const resp = await handleBacktest(defaultArgs(btArgs));
+          if (!resp.ok || !resp.data) return resp.error?.message ?? 'Backtest failed';
+          return formatBacktestHuman(resp.data, {
+            minEdge: btArgs.minEdge ?? 0.05,
+            minHoursBeforeClose: btArgs.minHoursBeforeClose ?? 24,
+            snapshotLast: btArgs.snapshotLast,
+          });
+        },
+      };
     }
 
     case 'config':

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -16,7 +16,7 @@ function defaultArgs(overrides: Partial<ParsedArgs>): ParsedArgs {
     subcommand: 'chat', positionalArgs: [], json: false,
     live: false, refresh: false, report: false, dryRun: false,
     verbose: false, performance: false, resolved: false,
-    unresolved: false, snapshotLast: false, parseErrors: [],
+    unresolved: false, parseErrors: [],
     ...overrides,
   };
 }
@@ -103,25 +103,17 @@ export async function handleSlashCommand(input: string): Promise<CommandResult |
         if (a === '--resolved') btArgs.resolved = true;
         else if (a === '--unresolved') btArgs.unresolved = true;
         else if (a === '--category') btArgs.category = args[++i];
-        else if (a === '--from') btArgs.from = args[++i];
-        else if (a === '--to') btArgs.to = args[++i];
+        else if (a === '--days') { const v = Number(args[++i]); if (Number.isFinite(v) && v > 0) btArgs.days = v; }
         else if (a === '--min-edge') { const v = Number(args[++i]?.replace('%', '')); if (Number.isFinite(v)) btArgs.minEdge = v / 100; }
-        else if (a === '--min-hours-before-close') { const v = Number(args[++i]); if (Number.isFinite(v)) btArgs.minHoursBeforeClose = v; }
-        else if (a === '--snapshot' && args[i + 1] === 'last') { btArgs.snapshotLast = true; i++; }
       }
       const mode = btArgs.resolved ? 'resolved markets' : btArgs.unresolved ? 'open markets' : 'resolved + open markets';
-      // Return a progress message immediately, then run the backtest
-      // The caller (cli.ts) will show this while the spinner is active
+      const daysLabel = btArgs.days ?? 30;
       return {
-        output: `Running backtest on ${mode}...`,
+        output: `Running ${daysLabel}-day backtest on ${mode}...`,
         asyncFollowUp: async () => {
           const resp = await handleBacktest(defaultArgs(btArgs));
           if (!resp.ok || !resp.data) return resp.error?.message ?? 'Backtest failed';
-          return formatBacktestHuman(resp.data, {
-            minEdge: btArgs.minEdge ?? 0.05,
-            minHoursBeforeClose: btArgs.minHoursBeforeClose ?? 24,
-            snapshotLast: btArgs.snapshotLast,
-          });
+          return formatBacktestHuman(resp.data, { minEdge: btArgs.minEdge ?? 0.05 });
         },
       };
     }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -20,6 +20,7 @@ function defaultArgs(overrides: Partial<ParsedArgs>): ParsedArgs {
     ...overrides,
   };
 }
+import { handleBacktest, formatBacktestHuman } from './backtest.js';
 import { handleAnalyze, formatAnalyzeHuman } from './analyze.js';
 import { handlePortfolio, formatPortfolioHuman } from './portfolio.js';
 import { reviewPortfolio, formatReviewHuman } from './review.js';
@@ -90,6 +91,30 @@ export async function handleSlashCommand(input: string): Promise<CommandResult |
     // ─── /review ─────────────────────────────────────────────────────
     case 'review':
       return handleReviewCommand();
+
+    // ─── /backtest ───────────────────────────────────────────────────
+    case 'backtest': {
+      // Parse backtest-specific flags from slash command args
+      const btArgs: Partial<ParsedArgs> = { subcommand: 'backtest' };
+      for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a === '--resolved') btArgs.resolved = true;
+        else if (a === '--unresolved') btArgs.unresolved = true;
+        else if (a === '--category') btArgs.category = args[++i];
+        else if (a === '--from') btArgs.from = args[++i];
+        else if (a === '--to') btArgs.to = args[++i];
+        else if (a === '--min-edge') { const v = Number(args[++i]?.replace('%', '')); if (Number.isFinite(v)) btArgs.minEdge = v / 100; }
+        else if (a === '--min-hours-before-close') { const v = Number(args[++i]); if (Number.isFinite(v)) btArgs.minHoursBeforeClose = v; }
+        else if (a === '--snapshot' && args[i + 1] === 'last') { btArgs.snapshotLast = true; i++; }
+      }
+      const resp = await handleBacktest(defaultArgs(btArgs));
+      if (!resp.ok || !resp.data) return { output: resp.error?.message ?? 'Backtest failed' };
+      return { output: formatBacktestHuman(resp.data, {
+        minEdge: btArgs.minEdge ?? 0.05,
+        minHoursBeforeClose: btArgs.minHoursBeforeClose ?? 24,
+        snapshotLast: btArgs.snapshotLast,
+      }) };
+    }
 
     case 'config':
       // Fall through to agent — better handled by the LLM

--- a/src/commands/parse-args.ts
+++ b/src/commands/parse-args.ts
@@ -33,6 +33,7 @@ export interface ParsedArgs {
   unresolved: boolean;
   days?: number;
   category?: string;
+  limit?: number;
   exportPath?: string;
   parseErrors: string[];
 }
@@ -58,6 +59,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
   let unresolved = false;
   let days: number | undefined;
   let category: string | undefined;
+  let limit: number | undefined;
   let exportPath: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
@@ -155,6 +157,13 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
         if (Number.isFinite(numeric) && numeric > 0) { days = numeric; }
         else { parseErrors.push(`Invalid --days value: "${raw}" (expected a positive number)`); }
       } else { parseErrors.push('--days requires a value'); }
+    } else if (arg === '--limit') {
+      const raw = argv[++i];
+      if (raw != null) {
+        const numeric = Number(raw);
+        if (Number.isFinite(numeric) && numeric > 0) { limit = numeric; }
+        else { parseErrors.push(`Invalid --limit value: "${raw}" (expected a positive number)`); }
+      } else { parseErrors.push('--limit requires a value'); }
     } else if (arg === '--export') {
       const val = argv[++i];
       if (val != null) { exportPath = val; } else { parseErrors.push('--export requires a value'); }
@@ -180,5 +189,5 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
     positionalArgs.unshift(first);
   }
 
-  return { subcommand, positionalArgs, json, theme, ticker, interval, since, minConfidence, minEdge, side, live, refresh, report, dryRun, verbose, performance, resolved, unresolved, days, category, exportPath, parseErrors };
+  return { subcommand, positionalArgs, json, theme, ticker, interval, since, minConfidence, minEdge, side, live, refresh, report, dryRun, verbose, performance, resolved, unresolved, days, category, limit, exportPath, parseErrors };
 }

--- a/src/commands/parse-args.ts
+++ b/src/commands/parse-args.ts
@@ -32,8 +32,6 @@ export interface ParsedArgs {
   resolved: boolean;
   unresolved: boolean;
   days?: number;
-  from?: string;
-  to?: string;
   category?: string;
   exportPath?: string;
   parseErrors: string[];
@@ -59,8 +57,6 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
   let resolved = false;
   let unresolved = false;
   let days: number | undefined;
-  let from: string | undefined;
-  let to: string | undefined;
   let category: string | undefined;
   let exportPath: string | undefined;
 
@@ -149,12 +145,6 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
       resolved = true;
     } else if (arg === '--unresolved') {
       unresolved = true;
-    } else if (arg === '--from') {
-      const val = argv[++i];
-      if (val != null) { from = val; } else { parseErrors.push('--from requires a value'); }
-    } else if (arg === '--to') {
-      const val = argv[++i];
-      if (val != null) { to = val; } else { parseErrors.push('--to requires a value'); }
     } else if (arg === '--category') {
       const val = argv[++i];
       if (val != null) { category = val; } else { parseErrors.push('--category requires a value'); }
@@ -190,5 +180,5 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
     positionalArgs.unshift(first);
   }
 
-  return { subcommand, positionalArgs, json, theme, ticker, interval, since, minConfidence, minEdge, side, live, refresh, report, dryRun, verbose, performance, resolved, unresolved, days, from, to, category, exportPath, parseErrors };
+  return { subcommand, positionalArgs, json, theme, ticker, interval, since, minConfidence, minEdge, side, live, refresh, report, dryRun, verbose, performance, resolved, unresolved, days, category, exportPath, parseErrors };
 }

--- a/src/commands/parse-args.ts
+++ b/src/commands/parse-args.ts
@@ -35,6 +35,7 @@ export interface ParsedArgs {
   to?: string;
   category?: string;
   minHoursBeforeClose?: number;
+  snapshotLast: boolean;
   exportPath?: string;
   parseErrors: string[];
 }
@@ -62,6 +63,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
   let to: string | undefined;
   let category: string | undefined;
   let minHoursBeforeClose: number | undefined;
+  let snapshotLast = false;
   let exportPath: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
@@ -165,6 +167,11 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
         if (Number.isFinite(numeric) && numeric >= 0) { minHoursBeforeClose = numeric; }
         else { parseErrors.push(`Invalid --min-hours-before-close value: "${raw}"`); }
       } else { parseErrors.push('--min-hours-before-close requires a value'); }
+    } else if (arg === '--snapshot') {
+      const val = argv[++i];
+      if (val === 'last') { snapshotLast = true; }
+      else if (val != null) { parseErrors.push(`Invalid --snapshot value: "${val}" (expected "last")`); }
+      else { parseErrors.push('--snapshot requires a value (e.g., --snapshot last)'); }
     } else if (arg === '--export') {
       const val = argv[++i];
       if (val != null) { exportPath = val; } else { parseErrors.push('--export requires a value'); }
@@ -186,5 +193,5 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
     positionalArgs.unshift(first);
   }
 
-  return { subcommand, positionalArgs, json, theme, ticker, interval, since, minConfidence, minEdge, side, live, refresh, report, dryRun, verbose, performance, resolved, unresolved, from, to, category, minHoursBeforeClose, exportPath, parseErrors };
+  return { subcommand, positionalArgs, json, theme, ticker, interval, since, minConfidence, minEdge, side, live, refresh, report, dryRun, verbose, performance, resolved, unresolved, from, to, category, minHoursBeforeClose, snapshotLast, exportPath, parseErrors };
 }

--- a/src/commands/parse-args.ts
+++ b/src/commands/parse-args.ts
@@ -5,6 +5,8 @@ const SUBCOMMANDS = [
   // Legacy aliases (kept for backward compat)
   'edge',
   'alerts', 'config', 'clear-cache', 'chat', 'init', 'status', 'themes',
+  // Backtest
+  'backtest',
 ] as const;
 
 export type Subcommand = (typeof SUBCOMMANDS)[number];
@@ -26,6 +28,14 @@ export interface ParsedArgs {
   dryRun: boolean;
   verbose: boolean;
   performance: boolean;
+  // Backtest-specific
+  resolved: boolean;
+  unresolved: boolean;
+  from?: string;
+  to?: string;
+  category?: string;
+  minHoursBeforeClose?: number;
+  exportPath?: string;
   parseErrors: string[];
 }
 
@@ -46,6 +56,13 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
   let dryRun = false;
   let verbose = false;
   let performance = false;
+  let resolved = false;
+  let unresolved = false;
+  let from: string | undefined;
+  let to: string | undefined;
+  let category: string | undefined;
+  let minHoursBeforeClose: number | undefined;
+  let exportPath: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -128,6 +145,29 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
       verbose = true;
     } else if (arg === '--performance') {
       performance = true;
+    } else if (arg === '--resolved') {
+      resolved = true;
+    } else if (arg === '--unresolved') {
+      unresolved = true;
+    } else if (arg === '--from') {
+      const val = argv[++i];
+      if (val != null) { from = val; } else { parseErrors.push('--from requires a value'); }
+    } else if (arg === '--to') {
+      const val = argv[++i];
+      if (val != null) { to = val; } else { parseErrors.push('--to requires a value'); }
+    } else if (arg === '--category') {
+      const val = argv[++i];
+      if (val != null) { category = val; } else { parseErrors.push('--category requires a value'); }
+    } else if (arg === '--min-hours-before-close') {
+      const raw = argv[++i];
+      if (raw != null) {
+        const numeric = Number(raw);
+        if (Number.isFinite(numeric) && numeric >= 0) { minHoursBeforeClose = numeric; }
+        else { parseErrors.push(`Invalid --min-hours-before-close value: "${raw}"`); }
+      } else { parseErrors.push('--min-hours-before-close requires a value'); }
+    } else if (arg === '--export') {
+      const val = argv[++i];
+      if (val != null) { exportPath = val; } else { parseErrors.push('--export requires a value'); }
     } else if (arg.startsWith('--')) {
       parseErrors.push(`Unknown flag: ${arg}`);
     } else {
@@ -146,5 +186,5 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
     positionalArgs.unshift(first);
   }
 
-  return { subcommand, positionalArgs, json, theme, ticker, interval, since, minConfidence, minEdge, side, live, refresh, report, dryRun, verbose, performance, parseErrors };
+  return { subcommand, positionalArgs, json, theme, ticker, interval, since, minConfidence, minEdge, side, live, refresh, report, dryRun, verbose, performance, resolved, unresolved, from, to, category, minHoursBeforeClose, exportPath, parseErrors };
 }

--- a/src/commands/parse-args.ts
+++ b/src/commands/parse-args.ts
@@ -31,11 +31,10 @@ export interface ParsedArgs {
   // Backtest-specific
   resolved: boolean;
   unresolved: boolean;
+  days?: number;
   from?: string;
   to?: string;
   category?: string;
-  minHoursBeforeClose?: number;
-  snapshotLast: boolean;
   exportPath?: string;
   parseErrors: string[];
 }
@@ -59,11 +58,10 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
   let performance = false;
   let resolved = false;
   let unresolved = false;
+  let days: number | undefined;
   let from: string | undefined;
   let to: string | undefined;
   let category: string | undefined;
-  let minHoursBeforeClose: number | undefined;
-  let snapshotLast = false;
   let exportPath: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
@@ -160,18 +158,13 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
     } else if (arg === '--category') {
       const val = argv[++i];
       if (val != null) { category = val; } else { parseErrors.push('--category requires a value'); }
-    } else if (arg === '--min-hours-before-close') {
+    } else if (arg === '--days') {
       const raw = argv[++i];
       if (raw != null) {
         const numeric = Number(raw);
-        if (Number.isFinite(numeric) && numeric >= 0) { minHoursBeforeClose = numeric; }
-        else { parseErrors.push(`Invalid --min-hours-before-close value: "${raw}"`); }
-      } else { parseErrors.push('--min-hours-before-close requires a value'); }
-    } else if (arg === '--snapshot') {
-      const val = argv[++i];
-      if (val === 'last') { snapshotLast = true; }
-      else if (val != null) { parseErrors.push(`Invalid --snapshot value: "${val}" (expected "last")`); }
-      else { parseErrors.push('--snapshot requires a value (e.g., --snapshot last)'); }
+        if (Number.isFinite(numeric) && numeric > 0) { days = numeric; }
+        else { parseErrors.push(`Invalid --days value: "${raw}" (expected a positive number)`); }
+      } else { parseErrors.push('--days requires a value'); }
     } else if (arg === '--export') {
       const val = argv[++i];
       if (val != null) { exportPath = val; } else { parseErrors.push('--export requires a value'); }
@@ -197,5 +190,5 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
     positionalArgs.unshift(first);
   }
 
-  return { subcommand, positionalArgs, json, theme, ticker, interval, since, minConfidence, minEdge, side, live, refresh, report, dryRun, verbose, performance, resolved, unresolved, from, to, category, minHoursBeforeClose, snapshotLast, exportPath, parseErrors };
+  return { subcommand, positionalArgs, json, theme, ticker, interval, since, minConfidence, minEdge, side, live, refresh, report, dryRun, verbose, performance, resolved, unresolved, days, from, to, category, exportPath, parseErrors };
 }

--- a/src/commands/parse-args.ts
+++ b/src/commands/parse-args.ts
@@ -182,6 +182,10 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
     }
   }
 
+  if (resolved && unresolved) {
+    parseErrors.push('Cannot use --resolved and --unresolved together');
+  }
+
   const first = positionalArgs.shift();
   const subcommand: Subcommand =
     first && (SUBCOMMANDS as readonly string[]).includes(first)

--- a/src/commands/search-edge.ts
+++ b/src/commands/search-edge.ts
@@ -1,0 +1,129 @@
+import type { Database } from 'bun:sqlite';
+
+export interface EdgeMarket {
+  market_ticker: string;
+  event_ticker: string;
+  model_prob: number;       // 0-100
+  market_prob: number;      // 0-100
+  edge_pp: number;          // model - market
+  direction: 'YES' | 'NO';
+  series_category: string;
+  confidence_score: number;
+}
+
+export interface EdgeScanResult {
+  markets: EdgeMarket[];
+  total_scanned: number;
+  events_scanned: number;
+}
+
+/**
+ * Scan all cached Octagon events for markets with edge above a threshold.
+ * Reads directly from SQLite — zero API calls, instant response.
+ */
+export function scanEdges(
+  db: Database,
+  opts?: { minEdgePp?: number; limit?: number; category?: string },
+): EdgeScanResult {
+  const minEdgePp = opts?.minEdgePp ?? 5;
+  const limit = opts?.limit ?? 20;
+  const category = opts?.category;
+
+  let query = `SELECT event_ticker, series_category, confidence_score, outcome_probabilities_json
+    FROM octagon_reports WHERE variant_used = 'events-api' AND outcome_probabilities_json IS NOT NULL`;
+  const params: Record<string, string> = {};
+  if (category) {
+    query += ' AND LOWER(series_category) LIKE $cat';
+    params.$cat = `%${category.toLowerCase()}%`;
+  }
+
+  const rows = db.query(query).all(params) as Array<{
+    event_ticker: string;
+    series_category: string | null;
+    confidence_score: number | null;
+    outcome_probabilities_json: string;
+  }>;
+
+  const allMarkets: EdgeMarket[] = [];
+  let totalScanned = 0;
+
+  for (const row of rows) {
+    let outcomes: Array<{ market_ticker: string; model_probability: number; market_probability: number }>;
+    try {
+      outcomes = JSON.parse(row.outcome_probabilities_json);
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(outcomes)) continue;
+
+    for (const o of outcomes) {
+      if (typeof o.model_probability !== 'number' || typeof o.market_probability !== 'number') continue;
+      if (!o.market_ticker) continue;
+      totalScanned++;
+      const edgePp = Math.round((o.model_probability - o.market_probability) * 10) / 10;
+      if (Math.abs(edgePp) < minEdgePp) continue;
+
+      allMarkets.push({
+        market_ticker: o.market_ticker,
+        event_ticker: row.event_ticker,
+        model_prob: o.model_probability,
+        market_prob: o.market_probability,
+        edge_pp: edgePp,
+        direction: edgePp > 0 ? 'YES' : 'NO',
+        series_category: row.series_category ?? '',
+        confidence_score: row.confidence_score ?? 0,
+      });
+    }
+  }
+
+  // Sort by |edge| descending
+  allMarkets.sort((a, b) => Math.abs(b.edge_pp) - Math.abs(a.edge_pp));
+
+  return {
+    markets: allMarkets.slice(0, limit),
+    total_scanned: totalScanned,
+    events_scanned: rows.length,
+  };
+}
+
+export function formatEdgeScanHuman(result: EdgeScanResult, minEdgePp: number): string {
+  const lines: string[] = [];
+  lines.push(`Octagon Edge Scanner — ${result.events_scanned} events, ${result.total_scanned} markets scanned`);
+  lines.push('════════════════════════════════════════════════════════');
+  lines.push('');
+
+  if (result.markets.length === 0) {
+    lines.push(`  No markets with |edge| ≥ ${minEdgePp}pp found.`);
+    return lines.join('\n');
+  }
+
+  const header = '  ' + [
+    '#'.padStart(3),
+    'Ticker'.padEnd(35),
+    'Model'.padStart(6),
+    'Market'.padStart(7),
+    'Edge'.padStart(7),
+    'Dir'.padStart(5),
+    'Category'.padEnd(15),
+  ].join('  ');
+  lines.push(header);
+
+  for (let i = 0; i < result.markets.length; i++) {
+    const m = result.markets[i];
+    const row = '  ' + [
+      String(i + 1).padStart(3),
+      m.market_ticker.padEnd(35),
+      `${m.model_prob.toFixed(0)}%`.padStart(6),
+      `${m.market_prob.toFixed(0)}%`.padStart(7),
+      `${m.edge_pp >= 0 ? '+' : ''}${m.edge_pp.toFixed(0)}pp`.padStart(7),
+      m.direction.padStart(5),
+      m.series_category.padEnd(15),
+    ].join('  ');
+    lines.push(row);
+  }
+
+  lines.push('');
+  lines.push(`${result.markets.length} markets with |edge| ≥ ${minEdgePp}pp`);
+
+  return lines.join('\n');
+}

--- a/src/commands/search-edge.ts
+++ b/src/commands/search-edge.ts
@@ -29,13 +29,19 @@ export function scanEdges(
   const limit = opts?.limit ?? 20;
   const category = opts?.category;
 
-  let query = `SELECT event_ticker, series_category, confidence_score, outcome_probabilities_json
+  let inner = `SELECT event_ticker, MAX(fetched_at) as max_fetched
     FROM octagon_reports WHERE variant_used = 'events-api' AND outcome_probabilities_json IS NOT NULL`;
   const params: Record<string, string> = {};
   if (category) {
-    query += ' AND LOWER(series_category) LIKE $cat';
+    inner += ' AND LOWER(series_category) LIKE $cat';
     params.$cat = `%${category.toLowerCase()}%`;
   }
+  inner += ' GROUP BY event_ticker';
+
+  const query = `SELECT r.event_ticker, r.series_category, r.confidence_score, r.outcome_probabilities_json
+    FROM octagon_reports r
+    INNER JOIN (${inner}) latest ON r.event_ticker = latest.event_ticker AND r.fetched_at = latest.max_fetched
+    WHERE r.variant_used = 'events-api' AND r.outcome_probabilities_json IS NOT NULL`;
 
   const rows = db.query(query).all(params) as Array<{
     event_ticker: string;

--- a/src/commands/search-edge.ts
+++ b/src/commands/search-edge.ts
@@ -65,6 +65,8 @@ export function scanEdges(
     for (const o of outcomes) {
       if (typeof o.model_probability !== 'number' || typeof o.market_probability !== 'number') continue;
       if (!o.market_ticker) continue;
+      // Skip markets with 0% or 100% market price (no liquidity or already settled)
+      if (o.market_probability <= 0 || o.market_probability >= 100) continue;
       totalScanned++;
       const edgePp = Math.round((o.model_probability - o.market_probability) * 10) / 10;
       if (Math.abs(edgePp) < minEdgePp) continue;

--- a/src/components/answer-box.ts
+++ b/src/components/answer-box.ts
@@ -1,10 +1,16 @@
-import { Container, Markdown, Spacer } from '@mariozechner/pi-tui';
+import { Container, Markdown, Spacer, type TUI } from '@mariozechner/pi-tui';
 import { formatResponse } from '../utils/markdown-table.js';
 import { markdownTheme, theme } from '../theme.js';
+
+const SPINNER_FRAMES = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'];
+const SPINNER_INTERVAL_MS = 80;
 
 export class AnswerBoxComponent extends Container {
   private readonly body: Markdown;
   private value = '';
+  private spinnerInterval: ReturnType<typeof setInterval> | null = null;
+  private spinnerFrame = 0;
+  private tui: TUI | null = null;
 
   constructor(initialText = '') {
     super();
@@ -16,8 +22,36 @@ export class AnswerBoxComponent extends Container {
 
   setText(text: string) {
     this.value = text;
-    const rendered = formatResponse(text);
+    this.render_();
+  }
+
+  /** Start an animated spinner prefix. Call stopSpinner() when done. */
+  startSpinner(tui: TUI) {
+    this.tui = tui;
+    this.spinnerFrame = 0;
+    if (this.spinnerInterval) return;
+    this.spinnerInterval = setInterval(() => {
+      this.spinnerFrame = (this.spinnerFrame + 1) % SPINNER_FRAMES.length;
+      this.render_();
+      this.tui?.requestRender();
+    }, SPINNER_INTERVAL_MS);
+  }
+
+  /** Stop the spinner and revert to static ⏺ prefix. */
+  stopSpinner() {
+    if (this.spinnerInterval) {
+      clearInterval(this.spinnerInterval);
+      this.spinnerInterval = null;
+    }
+    this.render_();
+  }
+
+  private render_() {
+    const rendered = formatResponse(this.value);
     const normalized = rendered.replace(/^\n+/, '');
-    this.body.setText(`${theme.primary('⏺')}\n${normalized}`);
+    const prefix = this.spinnerInterval
+      ? theme.primary(SPINNER_FRAMES[this.spinnerFrame])
+      : theme.primary('⏺');
+    this.body.setText(`${prefix}\n${normalized}`);
   }
 }

--- a/src/components/chat-log.ts
+++ b/src/components/chat-log.ts
@@ -253,13 +253,16 @@ export class ChatLogComponent extends Container {
     existing.setDenied(path, tool);
   }
 
-  finalizeAnswer(text: string) {
+  finalizeAnswer(text: string): AnswerBoxComponent {
     if (!this.activeAnswer) {
-      this.addChild(new AnswerBoxComponent(text));
-      return;
+      const box = new AnswerBoxComponent(text);
+      this.addChild(box);
+      return box;
     }
     this.activeAnswer.setText(text);
+    const box = this.activeAnswer;
     this.activeAnswer = null;
+    return box;
   }
 
   addContextCleared(clearedCount: number, keptCount: number) {

--- a/src/components/intro.ts
+++ b/src/components/intro.ts
@@ -67,7 +67,7 @@ export class IntroComponent extends Container {
     this.addChild(new Text('AI-powered prediction market terminal.', 0, 0));
     this.addChild(new Spacer(1));
     const cmd = (label: string) => theme.muted(label.padEnd(11));
-    this.addChild(new Text(cmd('/search') + 'Search events by theme, ticker, or free-text', 0, 0));
+    this.addChild(new Text(cmd('/search') + 'Search events by theme, ticker, or free-text; /search edge for edge scan', 0, 0));
     this.addChild(new Text(cmd('/portfolio') + 'Overview, positions, orders, balance, status', 0, 0));
     this.addChild(new Text(cmd('/analyze') + '<ticker>  Full analysis: edge, research, Kelly sizing', 0, 0));
     this.addChild(new Text(cmd('/watch') + '<ticker>  Live price/orderbook feed', 0, 0));

--- a/src/components/intro.ts
+++ b/src/components/intro.ts
@@ -12,7 +12,7 @@ export class IntroComponent extends Container {
     super();
 
     const isDemo = process.env.KALSHI_USE_DEMO === 'true';
-    const welcomeText = isDemo ? 'Kalshi Deep Trading Bot  [DEMO MODE]' : 'Kalshi Deep Trading Bot';
+    const welcomeText = isDemo ? 'Kalshi Trading Bot CLI  [DEMO MODE]' : 'Kalshi Trading Bot CLI';
     const versionText = ` v${packageJson.version}`;
     const fullText = welcomeText + versionText;
     const padding = Math.max(0, Math.floor((INTRO_WIDTH - fullText.length - 2) / 2));

--- a/src/components/intro.ts
+++ b/src/components/intro.ts
@@ -71,6 +71,7 @@ export class IntroComponent extends Container {
     this.addChild(new Text(cmd('/portfolio') + 'Overview, positions, orders, balance, status', 0, 0));
     this.addChild(new Text(cmd('/analyze') + '<ticker>  Full analysis: edge, research, Kelly sizing', 0, 0));
     this.addChild(new Text(cmd('/watch') + '<ticker>  Live price/orderbook feed', 0, 0));
+    this.addChild(new Text(cmd('/backtest') + 'Model accuracy scorecard + live edge scanner', 0, 0));
     this.addChild(new Text(cmd('/buy /sell') + '<ticker> <n> [price]   /cancel <order_id>', 0, 0));
     this.addChild(new Text(cmd('/help') + '[command]  Show help (/help <command> for details)', 0, 0));
     this.addChild(new Text(cmd('/quit') + 'Quit CLI session', 0, 0));

--- a/src/components/working-indicator.ts
+++ b/src/components/working-indicator.ts
@@ -61,6 +61,8 @@ export class WorkingIndicatorComponent extends Container {
       (text) => theme.primary(text),
       '',
     );
+    // Use larger braille block characters for a more visible spinner (ora's "dots2" style)
+    (this.loader as any).frames = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'];
     this.addChild(this.loader);
   }
 

--- a/src/controllers/browse.ts
+++ b/src/controllers/browse.ts
@@ -883,6 +883,38 @@ export class BrowseController {
    */
   private async extractAllOutcomeProbs(ticker: string): Promise<Map<string, number>> {
     const probs = new Map<string, number>();
+
+    // Try prefetch DB first to avoid an Octagon API call
+    try {
+      const db = getDb();
+      // Look up by event_ticker prefix (ticker may be a market ticker like KXBTC-26-B95000)
+      // Try exact match first, then find by event prefix
+      const row = db.query(
+        `SELECT outcome_probabilities_json FROM octagon_reports
+         WHERE variant_used = 'events-api' AND outcome_probabilities_json IS NOT NULL
+         AND (event_ticker = $t OR event_ticker IN (
+           SELECT event_ticker FROM octagon_reports WHERE ticker = $t AND variant_used != 'events-api' LIMIT 1
+         ))
+         ORDER BY fetched_at DESC LIMIT 1`,
+      ).get({ $t: ticker }) as { outcome_probabilities_json: string } | null;
+
+      if (row?.outcome_probabilities_json) {
+        const outcomes = JSON.parse(row.outcome_probabilities_json) as Array<{
+          market_ticker: string; model_probability: number;
+        }>;
+        for (const o of outcomes) {
+          if (typeof o.model_probability === 'number' && o.market_ticker) {
+            const prob = o.model_probability / 100;
+            if (prob >= 0 && prob <= 1) {
+              probs.set(o.market_ticker.toUpperCase(), prob);
+            }
+          }
+        }
+        if (probs.size > 0) return probs;
+      }
+    } catch { /* prefetch lookup failed — fall back to API */ }
+
+    // Fall back to individual Octagon cache API call
     try {
       const rawCache = await callOctagon(ticker, 'cache');
       const parsed = JSON.parse(rawCache);
@@ -894,7 +926,6 @@ export class BrowseController {
           ? JSON.parse(version.outcome_probabilities_json)
           : version.outcome_probabilities_json;
 
-      // Octagon API always returns percentages (0-100); normalize each value individually
       for (const o of outcomes) {
         if (typeof o.model_probability === 'number' && o.market_ticker) {
           const prob = o.model_probability / 100;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,6 +3,8 @@ import { mkdirSync } from 'fs';
 import { dirname } from 'path';
 import { migrate } from './schema.js';
 import { appPath } from '../utils/paths.js';
+import { prefetchOctagonEvents } from '../scan/octagon-prefetch.js';
+import { logger } from '../utils/logger.js';
 
 let _db: Database | null = null;
 
@@ -25,6 +27,12 @@ export function getDb(path?: string): Database {
   _db.exec('PRAGMA journal_mode = WAL');
   _db.exec('PRAGMA foreign_keys = ON');
   migrate(_db);
+
+  // Fire-and-forget: prefetch Octagon events in background
+  const db = _db;
+  prefetchOctagonEvents(db).catch((err) => {
+    logger.warn(`[octagon-prefetch] ${err instanceof Error ? err.message : err}`);
+  });
 
   return _db;
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,7 +4,6 @@ import { dirname } from 'path';
 import { migrate } from './schema.js';
 import { appPath } from '../utils/paths.js';
 import { prefetchOctagonEvents } from '../scan/octagon-prefetch.js';
-import { logger } from '../utils/logger.js';
 
 let _db: Database | null = null;
 
@@ -28,11 +27,11 @@ export function getDb(path?: string): Database {
   _db.exec('PRAGMA foreign_keys = ON');
   migrate(_db);
 
-  // Fire-and-forget: prefetch Octagon events in background
-  const db = _db;
-  prefetchOctagonEvents(db).catch((err) => {
-    logger.warn(`[octagon-prefetch] ${err instanceof Error ? err.message : err}`);
-  });
+  // Fire-and-forget: prefetch Octagon events in background (only for the real runtime DB)
+  if (dbPath === DEFAULT_DB_PATH) {
+    const db = _db;
+    prefetchOctagonEvents(db).catch(() => {});
+  }
 
   return _db;
 }

--- a/src/db/octagon-cache.ts
+++ b/src/db/octagon-cache.ts
@@ -20,23 +20,31 @@ export interface OctagonReport {
 }
 
 export function insertReport(db: Database, report: OctagonReport): void {
-  // Preserve has_history, mutually_exclusive, series_category from the existing row
-  // since INSERT OR REPLACE would reset them to defaults.
-  const existing = db.query(
-    'SELECT has_history, mutually_exclusive, series_category FROM octagon_reports WHERE report_id = $id',
-  ).get({ $id: report.report_id }) as { has_history: number; mutually_exclusive: number; series_category: string | null } | null;
-
   db.prepare(`
-    INSERT OR REPLACE INTO octagon_reports
+    INSERT INTO octagon_reports
       (report_id, ticker, event_ticker, model_prob, market_prob, mispricing_signal,
        drivers_json, catalysts_json, sources_json, resolution_history_json,
-       contract_snapshot_json, raw_response, model_accuracy, variant_used, fetched_at, expires_at,
-       has_history, mutually_exclusive, series_category)
+       contract_snapshot_json, raw_response, model_accuracy, variant_used, fetched_at, expires_at)
     VALUES
       ($report_id, $ticker, $event_ticker, $model_prob, $market_prob, $mispricing_signal,
        $drivers_json, $catalysts_json, $sources_json, $resolution_history_json,
-       $contract_snapshot_json, $raw_response, $model_accuracy, $variant_used, $fetched_at, $expires_at,
-       $has_history, $mutually_exclusive, $series_category)
+       $contract_snapshot_json, $raw_response, $model_accuracy, $variant_used, $fetched_at, $expires_at)
+    ON CONFLICT(report_id) DO UPDATE SET
+      ticker = EXCLUDED.ticker,
+      event_ticker = EXCLUDED.event_ticker,
+      model_prob = EXCLUDED.model_prob,
+      market_prob = EXCLUDED.market_prob,
+      mispricing_signal = EXCLUDED.mispricing_signal,
+      drivers_json = EXCLUDED.drivers_json,
+      catalysts_json = EXCLUDED.catalysts_json,
+      sources_json = EXCLUDED.sources_json,
+      resolution_history_json = EXCLUDED.resolution_history_json,
+      contract_snapshot_json = EXCLUDED.contract_snapshot_json,
+      raw_response = EXCLUDED.raw_response,
+      model_accuracy = EXCLUDED.model_accuracy,
+      variant_used = EXCLUDED.variant_used,
+      fetched_at = EXCLUDED.fetched_at,
+      expires_at = EXCLUDED.expires_at
   `).run({
     $report_id: report.report_id,
     $ticker: report.ticker,
@@ -54,9 +62,6 @@ export function insertReport(db: Database, report: OctagonReport): void {
     $variant_used: report.variant_used ?? null,
     $fetched_at: report.fetched_at,
     $expires_at: report.expires_at,
-    $has_history: existing?.has_history ?? 0,
-    $mutually_exclusive: existing?.mutually_exclusive ?? 0,
-    $series_category: existing?.series_category ?? null,
   });
 }
 

--- a/src/db/octagon-cache.ts
+++ b/src/db/octagon-cache.ts
@@ -20,15 +20,23 @@ export interface OctagonReport {
 }
 
 export function insertReport(db: Database, report: OctagonReport): void {
+  // Preserve has_history, mutually_exclusive, series_category from the existing row
+  // since INSERT OR REPLACE would reset them to defaults.
+  const existing = db.query(
+    'SELECT has_history, mutually_exclusive, series_category FROM octagon_reports WHERE report_id = $id',
+  ).get({ $id: report.report_id }) as { has_history: number; mutually_exclusive: number; series_category: string | null } | null;
+
   db.prepare(`
     INSERT OR REPLACE INTO octagon_reports
       (report_id, ticker, event_ticker, model_prob, market_prob, mispricing_signal,
        drivers_json, catalysts_json, sources_json, resolution_history_json,
-       contract_snapshot_json, raw_response, model_accuracy, variant_used, fetched_at, expires_at)
+       contract_snapshot_json, raw_response, model_accuracy, variant_used, fetched_at, expires_at,
+       has_history, mutually_exclusive, series_category)
     VALUES
       ($report_id, $ticker, $event_ticker, $model_prob, $market_prob, $mispricing_signal,
        $drivers_json, $catalysts_json, $sources_json, $resolution_history_json,
-       $contract_snapshot_json, $raw_response, $model_accuracy, $variant_used, $fetched_at, $expires_at)
+       $contract_snapshot_json, $raw_response, $model_accuracy, $variant_used, $fetched_at, $expires_at,
+       $has_history, $mutually_exclusive, $series_category)
   `).run({
     $report_id: report.report_id,
     $ticker: report.ticker,
@@ -46,6 +54,9 @@ export function insertReport(db: Database, report: OctagonReport): void {
     $variant_used: report.variant_used ?? null,
     $fetched_at: report.fetched_at,
     $expires_at: report.expires_at,
+    $has_history: existing?.has_history ?? 0,
+    $mutually_exclusive: existing?.mutually_exclusive ?? 0,
+    $series_category: existing?.series_category ?? null,
   });
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -212,4 +212,12 @@ export function migrate(db: Database): void {
   if (!reportCols.some((c) => c.name === 'confidence_score')) {
     db.exec(`ALTER TABLE octagon_reports ADD COLUMN confidence_score REAL`);
   }
+  if (!reportCols.some((c) => c.name === 'outcome_probabilities_json')) {
+    db.exec(`ALTER TABLE octagon_reports ADD COLUMN outcome_probabilities_json TEXT`);
+  }
+
+  const historyCols = db.query(`PRAGMA table_info(octagon_history)`).all() as Array<{ name: string }>;
+  if (!historyCols.some((c) => c.name === 'outcome_probabilities_json')) {
+    db.exec(`ALTER TABLE octagon_history ADD COLUMN outcome_probabilities_json TEXT`);
+  }
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -203,4 +203,10 @@ export function migrate(db: Database): void {
   if (!reportCols.some((c) => c.name === 'has_history')) {
     db.exec(`ALTER TABLE octagon_reports ADD COLUMN has_history INTEGER DEFAULT 0`);
   }
+  if (!reportCols.some((c) => c.name === 'mutually_exclusive')) {
+    db.exec(`ALTER TABLE octagon_reports ADD COLUMN mutually_exclusive INTEGER DEFAULT 0`);
+  }
+  if (!reportCols.some((c) => c.name === 'series_category')) {
+    db.exec(`ALTER TABLE octagon_reports ADD COLUMN series_category TEXT`);
+  }
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -209,4 +209,7 @@ export function migrate(db: Database): void {
   if (!reportCols.some((c) => c.name === 'series_category')) {
     db.exec(`ALTER TABLE octagon_reports ADD COLUMN series_category TEXT`);
   }
+  if (!reportCols.some((c) => c.name === 'confidence_score')) {
+    db.exec(`ALTER TABLE octagon_reports ADD COLUMN confidence_score REAL`);
+  }
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -162,6 +162,24 @@ export function migrate(db: Database): void {
       key   TEXT PRIMARY KEY,
       value TEXT NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS octagon_history (
+      id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+      history_id          INTEGER NOT NULL,
+      event_ticker        TEXT NOT NULL,
+      captured_at         TEXT NOT NULL,
+      model_probability   REAL NOT NULL,
+      market_probability  REAL NOT NULL,
+      edge_pp             REAL,
+      confidence_score    REAL,
+      series_category     TEXT,
+      close_time          TEXT,
+      name                TEXT,
+      UNIQUE(event_ticker, history_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_history_event
+      ON octagon_history(event_ticker, captured_at);
   `);
 
   // Schema migrations for columns added after initial release
@@ -180,5 +198,9 @@ export function migrate(db: Database): void {
     db.exec(`ALTER TABLE event_index ADD COLUMN tags TEXT`);
     // Force re-index so tags get populated on next ensureIndex() call
     db.exec(`DELETE FROM event_index_meta WHERE key = 'last_refresh'`);
+  }
+
+  if (!reportCols.some((c) => c.name === 'has_history')) {
+    db.exec(`ALTER TABLE octagon_reports ADD COLUMN has_history INTEGER DEFAULT 0`);
   }
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -175,6 +175,7 @@ export function migrate(db: Database): void {
       series_category     TEXT,
       close_time          TEXT,
       name                TEXT,
+      outcome_probabilities_json TEXT,
       UNIQUE(event_ticker, history_id)
     );
 

--- a/src/gateway/channels/whatsapp/README.md
+++ b/src/gateway/channels/whatsapp/README.md
@@ -44,7 +44,7 @@ Use your own WhatsApp to talk to the bot by messaging yourself. The linked phone
 
 If the bot has its own phone number (e.g. a separate SIM), choose this option and enter the phone number(s) allowed to message it. The gateway will be configured with `dmPolicy: "allowlist"` so other people can DM the bot.
 
-Credentials are saved to `.kalshi-deep-trading-bot/credentials/whatsapp/default/`.
+Credentials are saved to `.kalshi-trading-bot-cli/credentials/whatsapp/default/`.
 
 ## 🚀 How to Run
 
@@ -80,7 +80,7 @@ Bot: NVIDIA's revenue for fiscal year 2024 was $60.9 billion...
 
 ## ⚙️ Configuration
 
-The gateway configuration is stored at `.kalshi-deep-trading-bot/gateway.json`. It's auto-created when you run `gateway:login`.
+The gateway configuration is stored at `.kalshi-trading-bot-cli/gateway.json`. It's auto-created when you run `gateway:login`.
 
 **Self-chat configuration** (personal phone, message yourself):
 ```json
@@ -140,7 +140,7 @@ The bot can participate in WhatsApp group chats, responding only when @-mentione
 
 ### Setup
 
-Add group policy to your account in `.kalshi-deep-trading-bot/gateway.json`:
+Add group policy to your account in `.kalshi-trading-bot-cli/gateway.json`:
 
 ```jsonc
 {
@@ -182,7 +182,7 @@ If you need to relink your WhatsApp (e.g., after logging out or switching phones
 1. Stop the gateway (Ctrl+C)
 2. Delete the credentials:
    ```bash
-   rm -rf .kalshi-deep-trading-bot/credentials/whatsapp/default
+   rm -rf .kalshi-trading-bot-cli/credentials/whatsapp/default
    ```
 3. Run login again:
    ```bash
@@ -197,11 +197,11 @@ If you need to relink your WhatsApp (e.g., after logging out or switching phones
 - Try relinking (see above)
 
 **Messages not being received:**
-- Verify your phone number is in `allowFrom` in `.kalshi-deep-trading-bot/gateway.json`
+- Verify your phone number is in `allowFrom` in `.kalshi-trading-bot-cli/gateway.json`
 - Make sure you're messaging yourself (self-chat mode)
 
 **Debug logs:**
-- Check `.kalshi-deep-trading-bot/gateway-debug.log` for detailed logs
+- Check `.kalshi-trading-bot-cli/gateway-debug.log` for detailed logs
 
 ## 🔧 Full Reset
 
@@ -216,9 +216,9 @@ If you're experiencing persistent issues (connection problems, encryption errors
 
 3. **Clear all local data:**
    ```bash
-   rm -rf .kalshi-deep-trading-bot/credentials/whatsapp/default
-   rm -rf .kalshi-deep-trading-bot/gateway.json
-   rm -rf .kalshi-deep-trading-bot/gateway-debug.log
+   rm -rf .kalshi-trading-bot-cli/credentials/whatsapp/default
+   rm -rf .kalshi-trading-bot-cli/gateway.json
+   rm -rf .kalshi-trading-bot-cli/gateway-debug.log
    ```
 
 4. **Relink and start fresh:**

--- a/src/gateway/commands/handler.ts
+++ b/src/gateway/commands/handler.ts
@@ -21,6 +21,9 @@ function makeArgs(overrides: Partial<ParsedArgs>): ParsedArgs {
     dryRun: false,
     verbose: false,
     performance: false,
+    resolved: false,
+    unresolved: false,
+    snapshotLast: false,
     parseErrors: [],
     ...overrides,
   };

--- a/src/gateway/commands/handler.ts
+++ b/src/gateway/commands/handler.ts
@@ -23,7 +23,8 @@ function makeArgs(overrides: Partial<ParsedArgs>): ParsedArgs {
     performance: false,
     resolved: false,
     unresolved: false,
-    snapshotLast: false,
+
+
     parseErrors: [],
     ...overrides,
   };

--- a/src/scan/__tests__/octagon-client.test.ts
+++ b/src/scan/__tests__/octagon-client.test.ts
@@ -195,6 +195,25 @@ describe('OctagonClient', () => {
       expect(report.marketProb).toBeCloseTo(0.37, 4);
     });
 
+    test('handles outcome_probabilities_json as array (not string) with case-insensitive ticker match', () => {
+      const client = new OctagonClient(makeInvoker(''), db, audit);
+      const json = JSON.stringify({
+        versions: [{
+          model_probability: 1.6,
+          market_probability: 1.3,
+          outcome_probabilities_json: [
+            { market_ticker: 'KXPRESNOMR-28-TMAS', model_probability: 1.6, market_probability: 1.3 },
+            { market_ticker: 'KXPRESNOMR-28-JDV', model_probability: 37.69, market_probability: 37.0 },
+          ],
+        }],
+      });
+
+      // Mixed-case ticker should still match
+      const report = client.parseReport(json, 'kxpresnomr-28-jdv', 'KXPRESNOMR-28', 'cache');
+      expect(report.modelProb).toBeCloseTo(0.3769, 4);
+      expect(report.marketProb).toBeCloseTo(0.37, 4);
+    });
+
     test('falls back to event-level probability when ticker not in outcome_probabilities_json', () => {
       const client = new OctagonClient(makeInvoker(''), db, audit);
       const json = JSON.stringify({

--- a/src/scan/__tests__/octagon-client.test.ts
+++ b/src/scan/__tests__/octagon-client.test.ts
@@ -176,6 +176,41 @@ describe('OctagonClient', () => {
       expect(report.marketProb).toBe(0.65);
     });
 
+    test('extracts per-market probability from outcome_probabilities_json', () => {
+      const client = new OctagonClient(makeInvoker(''), db, audit);
+      const json = JSON.stringify({
+        versions: [{
+          model_probability: 1.6,
+          market_probability: 1.3,
+          outcome_probabilities_json: JSON.stringify([
+            { market_ticker: 'KXPRESNOMR-28-TMAS', model_probability: 1.6, market_probability: 1.3 },
+            { market_ticker: 'KXPRESNOMR-28-JDV', model_probability: 37.69, market_probability: 37.0 },
+            { market_ticker: 'KXPRESNOMR-28-MR', model_probability: 28.77, market_probability: 25.0 },
+          ]),
+        }],
+      });
+
+      const report = client.parseReport(json, 'KXPRESNOMR-28-JDV', 'KXPRESNOMR-28', 'cache');
+      expect(report.modelProb).toBeCloseTo(0.3769, 4);  // 37.69%, not 1.6%
+      expect(report.marketProb).toBeCloseTo(0.37, 4);
+    });
+
+    test('falls back to event-level probability when ticker not in outcome_probabilities_json', () => {
+      const client = new OctagonClient(makeInvoker(''), db, audit);
+      const json = JSON.stringify({
+        versions: [{
+          model_probability: 55.0,
+          market_probability: 50.0,
+          outcome_probabilities_json: JSON.stringify([
+            { market_ticker: 'OTHER-TICKER', model_probability: 30.0 },
+          ]),
+        }],
+      });
+
+      const report = client.parseReport(json, 'MISSING-TICKER', 'EVENT-1', 'cache');
+      expect(report.modelProb).toBeCloseTo(0.55, 4);  // falls back to event-level
+    });
+
     test('handles percentage values (e.g. "72%")', () => {
       const client = new OctagonClient(makeInvoker(''), db, audit);
       const json = JSON.stringify({ modelProb: '72%', marketProb: '65%' });

--- a/src/scan/__tests__/octagon-client.test.ts
+++ b/src/scan/__tests__/octagon-client.test.ts
@@ -209,6 +209,7 @@ describe('OctagonClient', () => {
 
       const report = client.parseReport(json, 'MISSING-TICKER', 'EVENT-1', 'cache');
       expect(report.modelProb).toBeCloseTo(0.55, 4);  // falls back to event-level
+      expect(report.marketProb).toBeCloseTo(0.50, 4);
     });
 
     test('handles percentage values (e.g. "72%")', () => {

--- a/src/scan/edge-computer.ts
+++ b/src/scan/edge-computer.ts
@@ -101,7 +101,11 @@ export class EdgeComputer {
 
       const results = await Promise.allSettled(
         reservedBatch.map(async (task) => {
-          const report = await octagonClient.fetchReport(
+          // Try prefetch first to avoid individual cache API calls
+          const prefetched = task.reservedVariant === 'cache'
+            ? octagonClient.tryFromPrefetch(task.market.ticker, task.eventTicker, task.market.close_time)
+            : null;
+          const report = prefetched ?? await octagonClient.fetchReport(
             task.market.ticker, task.eventTicker, task.reservedVariant,
             { creditsPreReserved: true, closeTimeIso: task.market.close_time },
           );

--- a/src/scan/octagon-client.ts
+++ b/src/scan/octagon-client.ts
@@ -283,11 +283,34 @@ export class OctagonClient {
     const versions = parsed.versions as Array<Record<string, unknown>> | undefined;
     const source = versions?.[0] ?? parsed;
 
-    // Octagon JSON API returns probabilities as percentages (0-100), not fractions.
-    // Use toProbFromJson which always divides by 100, unlike toProb which uses a
+    // For multi-outcome events, look up this specific market's probability
+    // from outcome_probabilities_json before falling back to event-level values.
+    // The event-level model_probability is typically the first outcome's value,
+    // not the one for the market we're analyzing.
+    let modelProb: number | null = null;
+    let marketProb: number | null = null;
+    const outcomeJson = (source as Record<string, unknown>).outcome_probabilities_json;
+    if (outcomeJson != null) {
+      try {
+        const outcomes = typeof outcomeJson === 'string'
+          ? JSON.parse(outcomeJson) : outcomeJson;
+        if (Array.isArray(outcomes)) {
+          const match = outcomes.find(
+            (o: { market_ticker?: string }) => String(o.market_ticker).toUpperCase() === defaults.ticker.toUpperCase()
+          );
+          if (match) {
+            modelProb = this.toProbFromJson(match.model_probability);
+            marketProb = this.toProbFromJson(match.market_probability);
+          }
+        }
+      } catch { /* malformed outcome JSON — fall through */ }
+    }
+
+    // Fall back to event-level values (correct for single-outcome markets).
+    // Uses toProbFromJson which always divides by 100, unlike toProb which uses a
     // > 1 heuristic that fails for sub-1% values (e.g. 0.9% stays as 0.9 → 90%).
-    const modelProb = this.toProbFromJson(source.modelProb ?? source.model_prob ?? source.model_probability) ?? defaults.modelProb;
-    const marketProb = this.toProbFromJson(source.marketProb ?? source.market_prob ?? source.market_probability) ?? defaults.marketProb;
+    modelProb = modelProb ?? this.toProbFromJson(source.modelProb ?? source.model_prob ?? source.model_probability) ?? defaults.modelProb;
+    marketProb = marketProb ?? this.toProbFromJson(source.marketProb ?? source.market_prob ?? source.market_probability) ?? defaults.marketProb;
 
     return {
       ...defaults,

--- a/src/scan/octagon-client.ts
+++ b/src/scan/octagon-client.ts
@@ -45,6 +45,77 @@ export class OctagonClient {
       ?? DEFAULT_DAILY_CREDIT_CEILING;
   }
 
+  /**
+   * Try to build an OctagonReport from the prefetched events API data in SQLite.
+   * Returns null if no fresh prefetch data is available for this event.
+   * This avoids an individual Octagon cache API call when the prefetch is fresh.
+   */
+  tryFromPrefetch(ticker: string, eventTicker: string, closeTimeIso?: string): OctagonReport | null {
+    const row = this.db.query(
+      `SELECT model_prob, market_prob, mispricing_signal, drivers_json, fetched_at, expires_at,
+              outcome_probabilities_json, report_id, confidence_score
+       FROM octagon_reports WHERE event_ticker = $et AND variant_used = 'events-api'
+       ORDER BY fetched_at DESC LIMIT 1`,
+    ).get({ $et: eventTicker }) as {
+      model_prob: number; market_prob: number | null; mispricing_signal: string | null;
+      drivers_json: string | null; fetched_at: number; expires_at: number;
+      outcome_probabilities_json: string | null; report_id: string;
+      confidence_score: number | null;
+    } | null;
+
+    if (!row) return null;
+
+    // Check if the prefetch is still fresh
+    const now = Math.floor(Date.now() / 1000);
+    if (row.expires_at < now) return null;
+
+    // Extract per-market probability if available
+    let modelProb = row.model_prob;
+    let marketProb = row.market_prob ?? 0.5;
+    if (row.outcome_probabilities_json) {
+      try {
+        const outcomes = JSON.parse(row.outcome_probabilities_json) as Array<{
+          market_ticker: string; model_probability: number; market_probability: number;
+        }>;
+        const match = outcomes.find(
+          o => o.market_ticker.toUpperCase() === ticker.toUpperCase(),
+        );
+        if (match) {
+          modelProb = match.model_probability / 100;
+          marketProb = match.market_probability / 100;
+        }
+      } catch { /* malformed JSON — use event-level */ }
+    }
+
+    // Parse drivers from prefetched data
+    let drivers: PriceDriver[] = [];
+    if (row.drivers_json) {
+      try { drivers = JSON.parse(row.drivers_json); } catch { /* skip */ }
+    }
+
+    const edge = modelProb - marketProb;
+    let signal: MispricingSignal = 'fair_value';
+    if (Math.abs(edge) >= 0.03) signal = edge > 0 ? 'underpriced' : 'overpriced';
+
+    return {
+      ticker,
+      eventTicker,
+      modelProb,
+      marketProb,
+      mispricingSignal: (row.mispricing_signal as MispricingSignal) ?? signal,
+      drivers,
+      catalysts: [],
+      sources: [],
+      resolutionHistory: '',
+      contractSnapshot: '',
+      variantUsed: 'cache',
+      fetchedAt: row.fetched_at,
+      rawResponse: '',
+      cacheMiss: false,
+      reportId: row.report_id,
+    };
+  }
+
   async fetchReport(
     ticker: string,
     eventTicker: string,

--- a/src/scan/octagon-client.ts
+++ b/src/scan/octagon-client.ts
@@ -142,10 +142,14 @@ export class OctagonClient {
           report = { ...defaults, cacheMiss: true };
           return report;
         }
-        // Check if model probability was actually provided
+        // Check if model probability was actually provided (event-level)
         const source = (versions?.[0] ?? parsed) as Record<string, unknown>;
         hasExplicitModelProb = (source.modelProb ?? source.model_prob ?? source.model_probability) != null;
         report = this.mapJsonToReport(parsed, defaults);
+        // Per-market probability from outcome_probabilities_json also counts as explicit
+        if (report.modelProb !== defaults.modelProb) {
+          hasExplicitModelProb = true;
+        }
       } else {
         report = this.extractFromMarkdown(raw, defaults);
       }

--- a/src/scan/octagon-events-api.ts
+++ b/src/scan/octagon-events-api.ts
@@ -25,6 +25,12 @@ export interface OctagonEventEntry {
   close_time: string;
   key_takeaway: string;
   has_history?: boolean;
+  outcome_probabilities?: Array<{
+    market_ticker: string;
+    outcome_name?: string;
+    model_probability: number;
+    market_probability: number;
+  }> | null;
   current_state_summary_richtext?: string;
   short_answer_richtext?: string;
   executive_summary_richtext?: string;

--- a/src/scan/octagon-events-api.ts
+++ b/src/scan/octagon-events-api.ts
@@ -26,6 +26,7 @@ export interface OctagonEventEntry {
   total_open_interest: number;
   close_time: string;
   key_takeaway: string;
+  has_history?: boolean;
   current_state_summary_richtext?: string;
   short_answer_richtext?: string;
   executive_summary_richtext?: string;
@@ -45,6 +46,8 @@ const TIMEOUT_MS = 60_000;
  * Fetch all events from the Octagon Prediction Markets Events API,
  * paginating through all pages.
  * @param opts.hasHistory - When true, only return events with multiple historical snapshots.
+ *   Note: The events list endpoint now returns `has_history` per event, so this filter
+ *   is only needed if you want to reduce response size.
  */
 export async function fetchAllOctagonEvents(opts?: { hasHistory?: boolean }): Promise<OctagonEventEntry[]> {
   const apiKey = process.env.OCTAGON_API_KEY;

--- a/src/scan/octagon-events-api.ts
+++ b/src/scan/octagon-events-api.ts
@@ -44,8 +44,9 @@ const TIMEOUT_MS = 60_000;
 /**
  * Fetch all events from the Octagon Prediction Markets Events API,
  * paginating through all pages.
+ * @param opts.hasHistory - When true, only return events with multiple historical snapshots.
  */
-export async function fetchAllOctagonEvents(): Promise<OctagonEventEntry[]> {
+export async function fetchAllOctagonEvents(opts?: { hasHistory?: boolean }): Promise<OctagonEventEntry[]> {
   const apiKey = process.env.OCTAGON_API_KEY;
   if (!apiKey) throw new Error('OCTAGON_API_KEY not set');
 
@@ -55,6 +56,7 @@ export async function fetchAllOctagonEvents(): Promise<OctagonEventEntry[]> {
 
   do {
     const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+    if (opts?.hasHistory) params.set('has_history', 'true');
     if (cursor) params.set('cursor', cursor);
 
     const controller = new AbortController();

--- a/src/scan/octagon-events-api.ts
+++ b/src/scan/octagon-events-api.ts
@@ -59,7 +59,6 @@ export async function fetchAllOctagonEvents(opts?: { hasHistory?: boolean }): Pr
 
   const all: OctagonEventEntry[] = [];
   let cursor: string | null = null;
-  let pageNum = 0;
 
   do {
     const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
@@ -98,7 +97,6 @@ export async function fetchAllOctagonEvents(opts?: { hasHistory?: boolean }): Pr
     }
     all.push(...(p.data as OctagonEventEntry[]));
     cursor = hasMore ? (p.next_cursor as string) : null;
-    pageNum++;
   } while (cursor);
 
   return all;

--- a/src/scan/octagon-events-api.ts
+++ b/src/scan/octagon-events-api.ts
@@ -1,0 +1,86 @@
+import { logger } from '../utils/logger.js';
+
+/**
+ * A single event entry from the Octagon Prediction Markets Events API.
+ * Probabilities are percentages (0-100).
+ */
+export interface OctagonEventEntry {
+  history_id: number;
+  run_id: string;
+  captured_at: string;
+  event_ticker: string;
+  name: string;
+  slug: string;
+  image_url?: string;
+  series_category: string;
+  available_on_brokers: boolean;
+  mutually_exclusive: boolean;
+  analysis_last_updated: string;
+  confidence_score: number;
+  model_probability: number;
+  market_probability: number;
+  edge_pp: number;
+  expected_return: number;
+  r_score: number;
+  total_volume: number;
+  total_open_interest: number;
+  close_time: string;
+  key_takeaway: string;
+  current_state_summary_richtext?: string;
+  short_answer_richtext?: string;
+  executive_summary_richtext?: string;
+}
+
+interface EventsPage {
+  data: OctagonEventEntry[];
+  next_cursor: string | null;
+  has_more: boolean;
+}
+
+const EVENTS_API_BASE = 'https://api.octagonai.co/v1';
+const PAGE_LIMIT = 200;
+const TIMEOUT_MS = 60_000;
+
+/**
+ * Fetch all events from the Octagon Prediction Markets Events API,
+ * paginating through all pages.
+ */
+export async function fetchAllOctagonEvents(): Promise<OctagonEventEntry[]> {
+  const apiKey = process.env.OCTAGON_API_KEY;
+  if (!apiKey) throw new Error('OCTAGON_API_KEY not set');
+
+  const all: OctagonEventEntry[] = [];
+  let cursor: string | null = null;
+  let pageNum = 0;
+
+  do {
+    const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+    if (cursor) params.set('cursor', cursor);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    let resp: Response;
+    try {
+      resp = await fetch(`${EVENTS_API_BASE}/prediction-markets/events?${params}`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '');
+      throw new Error(`Octagon events API ${resp.status}: ${body.slice(0, 200)}`);
+    }
+
+    const page = (await resp.json()) as EventsPage;
+    all.push(...page.data);
+    cursor = page.has_more ? page.next_cursor : null;
+    pageNum++;
+    logger.info(`[octagon-prefetch] Page ${pageNum}: ${page.data.length} events (total ${all.length})`);
+  } while (cursor);
+
+  return all;
+}

--- a/src/scan/octagon-events-api.ts
+++ b/src/scan/octagon-events-api.ts
@@ -1,5 +1,3 @@
-import { logger } from '../utils/logger.js';
-
 /**
  * A single event entry from the Octagon Prediction Markets Events API.
  * Probabilities are percentages (0-100).
@@ -80,11 +78,21 @@ export async function fetchAllOctagonEvents(opts?: { hasHistory?: boolean }): Pr
       throw new Error(`Octagon events API ${resp.status}: ${body.slice(0, 200)}`);
     }
 
-    const page = (await resp.json()) as EventsPage;
-    all.push(...page.data);
-    cursor = page.has_more ? page.next_cursor : null;
+    const page = (await resp.json()) as unknown;
+    if (!page || typeof page !== 'object') {
+      throw new Error('Octagon events API returned invalid response shape');
+    }
+    const p = page as Record<string, unknown>;
+    if (!Array.isArray(p.data)) {
+      throw new Error('Octagon events API response missing data array');
+    }
+    const hasMore = typeof p.has_more === 'boolean' ? p.has_more : false;
+    if (hasMore && !p.next_cursor) {
+      throw new Error('Octagon events API has_more=true but next_cursor is missing');
+    }
+    all.push(...(p.data as OctagonEventEntry[]));
+    cursor = hasMore ? (p.next_cursor as string) : null;
     pageNum++;
-    logger.info(`[octagon-prefetch] Page ${pageNum}: ${page.data.length} events (total ${all.length})`);
   } while (cursor);
 
   return all;

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -133,15 +133,21 @@ export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: n
     }
   }
 
-  // Mark has_history directly from the response field (no second API call needed)
-  const markHistory = db.prepare(
-    "UPDATE octagon_reports SET has_history = $hh WHERE event_ticker = $et AND variant_used = 'events-api'",
+  // Mark has_history, mutually_exclusive, series_category from the response
+  const markMeta = db.prepare(
+    `UPDATE octagon_reports SET has_history = $hh, mutually_exclusive = $me, series_category = $sc
+     WHERE event_ticker = $et AND variant_used = 'events-api'`,
   );
   let historyCount = 0;
   db.transaction(() => {
     for (const event of events) {
       const hh = event.has_history ? 1 : 0;
-      markHistory.run({ $et: event.event_ticker, $hh: hh });
+      markMeta.run({
+        $et: event.event_ticker,
+        $hh: hh,
+        $me: event.mutually_exclusive ? 1 : 0,
+        $sc: event.series_category ?? null,
+      });
       if (hh) historyCount++;
     }
   })();

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -143,7 +143,7 @@ export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: n
 
   // Mark has_history, mutually_exclusive, series_category from the response
   const markMeta = db.prepare(
-    `UPDATE octagon_reports SET has_history = $hh, mutually_exclusive = $me, series_category = $sc, confidence_score = $cs
+    `UPDATE octagon_reports SET has_history = $hh, mutually_exclusive = $me, series_category = $sc, confidence_score = $cs, outcome_probabilities_json = $opj
      WHERE event_ticker = $et AND variant_used = 'events-api'`,
   );
   db.transaction(() => {
@@ -154,6 +154,7 @@ export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: n
         $me: event.mutually_exclusive ? 1 : 0,
         $sc: event.series_category ?? null,
         $cs: event.confidence_score ?? null,
+        $opj: event.outcome_probabilities ? JSON.stringify(event.outcome_probabilities) : null,
       });
     }
   })();

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -143,7 +143,7 @@ export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: n
 
   // Mark has_history, mutually_exclusive, series_category from the response
   const markMeta = db.prepare(
-    `UPDATE octagon_reports SET has_history = $hh, mutually_exclusive = $me, series_category = $sc
+    `UPDATE octagon_reports SET has_history = $hh, mutually_exclusive = $me, series_category = $sc, confidence_score = $cs
      WHERE event_ticker = $et AND variant_used = 'events-api'`,
   );
   db.transaction(() => {
@@ -153,6 +153,7 @@ export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: n
         $hh: event.has_history ? 1 : 0,
         $me: event.mutually_exclusive ? 1 : 0,
         $sc: event.series_category ?? null,
+        $cs: event.confidence_score ?? null,
       });
     }
   })();

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -108,9 +108,11 @@ function persistEvent(db: Database, event: OctagonEventEntry): boolean {
       confidence: classifyConfidence(Math.abs(edge)),
     });
   } catch (err) {
-    // UNIQUE constraint violation if edge already exists for this ticker+timestamp — OK
+    // Only swallow UNIQUE constraint violations (duplicate ticker+timestamp)
     const msg = err instanceof Error ? err.message : String(err);
-    if (!msg.includes('UNIQUE') && !msg.includes('constraint')) {
+    if (/UNIQUE constraint failed/i.test(msg)) {
+      // Expected — edge already exists for this ticker+timestamp
+    } else {
       throw err;
     }
   }

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -1,0 +1,139 @@
+import type { Database } from 'bun:sqlite';
+import { fetchAllOctagonEvents, type OctagonEventEntry } from './octagon-events-api.js';
+import { insertReport, getLatestReport, getTtlForCloseTime } from '../db/octagon-cache.js';
+import { insertEdge } from '../db/edge.js';
+import { logger } from '../utils/logger.js';
+
+const PREFETCH_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+const META_KEY = 'octagon_prefetch_at';
+
+/**
+ * Check if a prefetch is needed (more than 1h since last one).
+ */
+function shouldPrefetch(db: Database): boolean {
+  const row = db.query("SELECT value FROM event_index_meta WHERE key = $key").get({
+    $key: META_KEY,
+  }) as { value: string } | null;
+  if (!row) return true;
+  const lastPrefetch = parseInt(row.value, 10);
+  return Date.now() - lastPrefetch > PREFETCH_COOLDOWN_MS;
+}
+
+function markPrefetchDone(db: Database): void {
+  db.query("INSERT OR REPLACE INTO event_index_meta (key, value) VALUES ($key, $value)").run({
+    $key: META_KEY,
+    $value: String(Date.now()),
+  });
+}
+
+/**
+ * Infer a mispricing signal from the edge.
+ */
+function inferSignal(modelProb: number, marketProb: number): string {
+  const edge = modelProb - marketProb;
+  if (Math.abs(edge) < 0.03) return 'fair_value';
+  return edge > 0 ? 'underpriced' : 'overpriced';
+}
+
+/**
+ * Classify confidence from absolute edge.
+ */
+function classifyConfidence(absEdge: number): string {
+  if (absEdge >= 0.10) return 'very_high';
+  if (absEdge >= 0.05) return 'high';
+  if (absEdge >= 0.02) return 'moderate';
+  return 'low';
+}
+
+/**
+ * Convert an Octagon event entry to local DB records and persist.
+ * Returns true if a new record was inserted, false if skipped.
+ */
+function persistEvent(db: Database, event: OctagonEventEntry): boolean {
+  const capturedAt = Math.floor(new Date(event.captured_at).getTime() / 1000);
+  const closeTime = Math.floor(new Date(event.close_time).getTime() / 1000);
+
+  // Probabilities from the events API are percentages (0-100)
+  const modelProb = event.model_probability / 100;
+  const marketProb = event.market_probability / 100;
+
+  // Skip if we already have a fresher report for this event
+  const existing = getLatestReport(db, event.event_ticker);
+  if (existing && existing.fetched_at >= capturedAt) return false;
+
+  const ttl = getTtlForCloseTime(Math.max(0, closeTime - capturedAt));
+  const reportId = `events-api-${event.event_ticker}-${capturedAt}`;
+
+  insertReport(db, {
+    report_id: reportId,
+    ticker: event.event_ticker,
+    event_ticker: event.event_ticker,
+    model_prob: modelProb,
+    market_prob: marketProb,
+    mispricing_signal: inferSignal(modelProb, marketProb),
+    drivers_json: JSON.stringify([{
+      claim: event.key_takeaway || event.name,
+      category: (event.series_category || 'other').toLowerCase(),
+      impact: 'medium',
+    }]),
+    catalysts_json: null,
+    sources_json: null,
+    resolution_history_json: null,
+    contract_snapshot_json: null,
+    raw_response: null,
+    variant_used: 'events-api',
+    fetched_at: capturedAt,
+    expires_at: capturedAt + ttl,
+  });
+
+  // Also persist to edge_history
+  const edge = modelProb - marketProb;
+  try {
+    insertEdge(db, {
+      ticker: event.event_ticker,
+      event_ticker: event.event_ticker,
+      timestamp: capturedAt,
+      model_prob: modelProb,
+      market_prob: marketProb,
+      edge,
+      octagon_report_id: reportId,
+      drivers_json: null,
+      sources_json: null,
+      catalysts_json: null,
+      cache_hit: 1,
+      cache_miss: 0,
+      confidence: classifyConfidence(Math.abs(edge)),
+    });
+  } catch {
+    // UNIQUE constraint violation if edge already exists for this ticker+timestamp — OK
+  }
+
+  return true;
+}
+
+/**
+ * Fetch all Octagon events via the REST API and persist them locally.
+ * Runs only if the last prefetch was more than 1h ago.
+ */
+export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: number; skipped: number }> {
+  if (!shouldPrefetch(db)) {
+    logger.info('[octagon-prefetch] Skipping — last prefetch within cooldown');
+    return { inserted: 0, skipped: 0 };
+  }
+
+  const events = await fetchAllOctagonEvents();
+  let inserted = 0;
+  let skipped = 0;
+
+  for (const event of events) {
+    if (persistEvent(db, event)) {
+      inserted++;
+    } else {
+      skipped++;
+    }
+  }
+
+  markPrefetchDone(db);
+  logger.info(`[octagon-prefetch] Done: ${inserted} inserted, ${skipped} skipped (${events.length} total events)`);
+  return { inserted, skipped };
+}

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -133,6 +133,23 @@ export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: n
     }
   }
 
+  // Mark which events have historical snapshots available
+  try {
+    const eventsWithHistory = await fetchAllOctagonEvents({ hasHistory: true });
+    const historyTickers = new Set(eventsWithHistory.map(e => e.event_ticker));
+    const markHistory = db.prepare(
+      "UPDATE octagon_reports SET has_history = 1 WHERE event_ticker = $et AND variant_used = 'events-api'",
+    );
+    db.transaction(() => {
+      for (const et of historyTickers) {
+        markHistory.run({ $et: et });
+      }
+    })();
+    logger.info(`[octagon-prefetch] Marked ${historyTickers.size} events with history`);
+  } catch (err) {
+    logger.warn(`[octagon-prefetch] Failed to mark has_history: ${err instanceof Error ? err.message : err}`);
+  }
+
   markPrefetchDone(db);
   logger.info(`[octagon-prefetch] Done: ${inserted} inserted, ${skipped} skipped (${events.length} total events)`);
   return { inserted, skipped };

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -89,6 +89,20 @@ function persistEvent(db: Database, event: OctagonEventEntry): boolean {
     expires_at: capturedAt + ttl,
   });
 
+  // Set metadata fields atomically on this specific report
+  db.prepare(
+    `UPDATE octagon_reports SET has_history = $hh, mutually_exclusive = $me, series_category = $sc,
+       confidence_score = $cs, outcome_probabilities_json = $opj
+     WHERE report_id = $rid`,
+  ).run({
+    $rid: reportId,
+    $hh: event.has_history ? 1 : 0,
+    $me: event.mutually_exclusive ? 1 : 0,
+    $sc: event.series_category ?? null,
+    $cs: event.confidence_score ?? null,
+    $opj: event.outcome_probabilities ? JSON.stringify(event.outcome_probabilities) : null,
+  });
+
   // Also persist to edge_history
   const edge = modelProb - marketProb;
   try {
@@ -140,24 +154,6 @@ export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: n
       skipped++;
     }
   }
-
-  // Mark has_history, mutually_exclusive, series_category from the response
-  const markMeta = db.prepare(
-    `UPDATE octagon_reports SET has_history = $hh, mutually_exclusive = $me, series_category = $sc, confidence_score = $cs, outcome_probabilities_json = $opj
-     WHERE event_ticker = $et AND variant_used = 'events-api'`,
-  );
-  db.transaction(() => {
-    for (const event of events) {
-      markMeta.run({
-        $et: event.event_ticker,
-        $hh: event.has_history ? 1 : 0,
-        $me: event.mutually_exclusive ? 1 : 0,
-        $sc: event.series_category ?? null,
-        $cs: event.confidence_score ?? null,
-        $opj: event.outcome_probabilities ? JSON.stringify(event.outcome_probabilities) : null,
-      });
-    }
-  })();
 
   markPrefetchDone(db);
   return { inserted, skipped };

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -133,22 +133,19 @@ export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: n
     }
   }
 
-  // Mark which events have historical snapshots available
-  try {
-    const eventsWithHistory = await fetchAllOctagonEvents({ hasHistory: true });
-    const historyTickers = new Set(eventsWithHistory.map(e => e.event_ticker));
-    const markHistory = db.prepare(
-      "UPDATE octagon_reports SET has_history = 1 WHERE event_ticker = $et AND variant_used = 'events-api'",
-    );
-    db.transaction(() => {
-      for (const et of historyTickers) {
-        markHistory.run({ $et: et });
-      }
-    })();
-    logger.info(`[octagon-prefetch] Marked ${historyTickers.size} events with history`);
-  } catch (err) {
-    logger.warn(`[octagon-prefetch] Failed to mark has_history: ${err instanceof Error ? err.message : err}`);
-  }
+  // Mark has_history directly from the response field (no second API call needed)
+  const markHistory = db.prepare(
+    "UPDATE octagon_reports SET has_history = $hh WHERE event_ticker = $et AND variant_used = 'events-api'",
+  );
+  let historyCount = 0;
+  db.transaction(() => {
+    for (const event of events) {
+      const hh = event.has_history ? 1 : 0;
+      markHistory.run({ $et: event.event_ticker, $hh: hh });
+      if (hh) historyCount++;
+    }
+  })();
+  logger.info(`[octagon-prefetch] Marked ${historyCount}/${events.length} events with history`);
 
   markPrefetchDone(db);
   logger.info(`[octagon-prefetch] Done: ${inserted} inserted, ${skipped} skipped (${events.length} total events)`);

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -67,41 +67,43 @@ function persistEvent(db: Database, event: OctagonEventEntry): boolean {
   const ttl = getTtlForCloseTime(Math.max(0, closeTime - capturedAt));
   const reportId = `events-api-${event.event_ticker}-${capturedAt}`;
 
-  insertReport(db, {
-    report_id: reportId,
-    ticker: event.event_ticker,
-    event_ticker: event.event_ticker,
-    model_prob: modelProb,
-    market_prob: marketProb,
-    mispricing_signal: inferSignal(modelProb, marketProb),
-    drivers_json: JSON.stringify([{
-      claim: event.key_takeaway || event.name,
-      category: (event.series_category || 'other').toLowerCase(),
-      impact: 'medium',
-    }]),
-    catalysts_json: null,
-    sources_json: null,
-    resolution_history_json: null,
-    contract_snapshot_json: null,
-    raw_response: null,
-    variant_used: 'events-api',
-    fetched_at: capturedAt,
-    expires_at: capturedAt + ttl,
-  });
+  // Insert report and set metadata in a single transaction
+  db.transaction(() => {
+    insertReport(db, {
+      report_id: reportId,
+      ticker: event.event_ticker,
+      event_ticker: event.event_ticker,
+      model_prob: modelProb,
+      market_prob: marketProb,
+      mispricing_signal: inferSignal(modelProb, marketProb),
+      drivers_json: JSON.stringify([{
+        claim: event.key_takeaway || event.name,
+        category: (event.series_category || 'other').toLowerCase(),
+        impact: 'medium',
+      }]),
+      catalysts_json: null,
+      sources_json: null,
+      resolution_history_json: null,
+      contract_snapshot_json: null,
+      raw_response: null,
+      variant_used: 'events-api',
+      fetched_at: capturedAt,
+      expires_at: capturedAt + ttl,
+    });
 
-  // Set metadata fields atomically on this specific report
-  db.prepare(
-    `UPDATE octagon_reports SET has_history = $hh, mutually_exclusive = $me, series_category = $sc,
-       confidence_score = $cs, outcome_probabilities_json = $opj
-     WHERE report_id = $rid`,
-  ).run({
-    $rid: reportId,
-    $hh: event.has_history ? 1 : 0,
-    $me: event.mutually_exclusive ? 1 : 0,
-    $sc: event.series_category ?? null,
-    $cs: event.confidence_score ?? null,
-    $opj: event.outcome_probabilities ? JSON.stringify(event.outcome_probabilities) : null,
-  });
+    db.prepare(
+      `UPDATE octagon_reports SET has_history = $hh, mutually_exclusive = $me, series_category = $sc,
+         confidence_score = $cs, outcome_probabilities_json = $opj
+       WHERE report_id = $rid`,
+    ).run({
+      $rid: reportId,
+      $hh: event.has_history ? 1 : 0,
+      $me: event.mutually_exclusive ? 1 : 0,
+      $sc: event.series_category ?? null,
+      $cs: event.confidence_score ?? null,
+      $opj: event.outcome_probabilities ? JSON.stringify(event.outcome_probabilities) : null,
+    });
+  })();
 
   // Also persist to edge_history
   const edge = modelProb - marketProb;

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -50,8 +50,11 @@ function classifyConfidence(absEdge: number): string {
  * Returns true if a new record was inserted, false if skipped.
  */
 function persistEvent(db: Database, event: OctagonEventEntry): boolean {
-  const capturedAt = Math.floor(new Date(event.captured_at).getTime() / 1000);
-  const closeTime = Math.floor(new Date(event.close_time).getTime() / 1000);
+  const capturedDate = new Date(event.captured_at);
+  const closeDate = new Date(event.close_time);
+  if (isNaN(capturedDate.getTime()) || isNaN(closeDate.getTime())) return false;
+  const capturedAt = Math.floor(capturedDate.getTime() / 1000);
+  const closeTime = Math.floor(closeDate.getTime() / 1000);
 
   // Probabilities from the events API are percentages (0-100)
   const modelProb = event.model_probability / 100;

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -2,7 +2,6 @@ import type { Database } from 'bun:sqlite';
 import { fetchAllOctagonEvents, type OctagonEventEntry } from './octagon-events-api.js';
 import { insertReport, getLatestReport, getTtlForCloseTime } from '../db/octagon-cache.js';
 import { insertEdge } from '../db/edge.js';
-import { logger } from '../utils/logger.js';
 
 const PREFETCH_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 const META_KEY = 'octagon_prefetch_at';
@@ -16,6 +15,7 @@ function shouldPrefetch(db: Database): boolean {
   }) as { value: string } | null;
   if (!row) return true;
   const lastPrefetch = parseInt(row.value, 10);
+  if (!Number.isFinite(lastPrefetch)) return true;
   return Date.now() - lastPrefetch > PREFETCH_COOLDOWN_MS;
 }
 
@@ -104,8 +104,12 @@ function persistEvent(db: Database, event: OctagonEventEntry): boolean {
       cache_miss: 0,
       confidence: classifyConfidence(Math.abs(edge)),
     });
-  } catch {
+  } catch (err) {
     // UNIQUE constraint violation if edge already exists for this ticker+timestamp — OK
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes('UNIQUE') && !msg.includes('constraint')) {
+      throw err;
+    }
   }
 
   return true;
@@ -117,7 +121,6 @@ function persistEvent(db: Database, event: OctagonEventEntry): boolean {
  */
 export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: number; skipped: number }> {
   if (!shouldPrefetch(db)) {
-    logger.info('[octagon-prefetch] Skipping — last prefetch within cooldown');
     return { inserted: 0, skipped: 0 };
   }
 
@@ -151,9 +154,7 @@ export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: n
       if (hh) historyCount++;
     }
   })();
-  logger.info(`[octagon-prefetch] Marked ${historyCount}/${events.length} events with history`);
 
   markPrefetchDone(db);
-  logger.info(`[octagon-prefetch] Done: ${inserted} inserted, ${skipped} skipped (${events.length} total events)`);
   return { inserted, skipped };
 }

--- a/src/scan/octagon-prefetch.ts
+++ b/src/scan/octagon-prefetch.ts
@@ -146,17 +146,14 @@ export async function prefetchOctagonEvents(db: Database): Promise<{ inserted: n
     `UPDATE octagon_reports SET has_history = $hh, mutually_exclusive = $me, series_category = $sc
      WHERE event_ticker = $et AND variant_used = 'events-api'`,
   );
-  let historyCount = 0;
   db.transaction(() => {
     for (const event of events) {
-      const hh = event.has_history ? 1 : 0;
       markMeta.run({
         $et: event.event_ticker,
-        $hh: hh,
+        $hh: event.has_history ? 1 : 0,
         $me: event.mutually_exclusive ? 1 : 0,
         $sc: event.series_category ?? null,
       });
-      if (hh) historyCount++;
     }
   })();
 

--- a/src/setup/wizard.ts
+++ b/src/setup/wizard.ts
@@ -104,7 +104,7 @@ export class SetupWizardController {
   getTitle(): string {
     switch (this.wizardState) {
       case 'welcome':
-        return 'Welcome to Kalshi Deep Trading Bot';
+        return 'Welcome to Kalshi Trading Bot CLI';
       case 'kalshi_api_key':
         return 'Step 1/5: Kalshi API Key';
       case 'kalshi_private_key':


### PR DESCRIPTION
mapJsonToReport() was reading the event-level model_probability (which corresponds to the first outcome) instead of looking up the per-market probability from outcome_probabilities_json. This caused wildly incorrect edge calculations for elections, sports, and entertainment markets.

Now checks outcome_probabilities_json for the specific market ticker before falling back to the event-level value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Octagon events ingestion with background prefetch, full backtest suite (history fetch/cache, discovery, metrics), human-readable backtest report + CSV export, new backtest CLI/slash command with async follow-up, and an edge scanner/search subcommand.

* **Bug Fixes**
  * Probability parsing now prefers per-market probabilities when present (case-insensitive matching) and falls back to event-level values; explicit-probability detection improved.

* **Tests**
  * Added unit tests covering per-market probability extraction and fallback behavior.

* **Chores**
  * DB schema/migrations updated for history & report fields; report upsert made safer; docs/branding renamed to “Kalshi Trading Bot CLI”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->