### PR TITLE
fix(backtest): remove line from output

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,6 @@ kalshi backtest --export results.csv         # per-market detail
 Octagon Backtest — 15-day lookback (04/02 – 04/17)
 ══════════════════════════════════════════════════════════
 
-VERDICT: Model has edge (Skill +12.5% [CI: +4.1%, +20.8%]; ROI +7.8%)
-
   Events         83
   Markets        247   (142 resolved, 105 unresolved)
   Brier (Octagon)   0.168

--- a/src/backtest/renderer.ts
+++ b/src/backtest/renderer.ts
@@ -37,8 +37,6 @@ export function formatBacktestHuman(result: BacktestResult, opts?: FormatOpts): 
   }
 
   // Unified scorecard
-  lines.push(`VERDICT: ${result.verdict.summary}`);
-  lines.push('');
   lines.push(`  Events         ${result.events_scored}`);
   lines.push(`  Markets        ${result.markets_resolved + result.markets_unresolved}   (${result.markets_resolved} resolved, ${result.markets_unresolved} unresolved)`);
   lines.push('');


### PR DESCRIPTION
The skill-score-based can be misleading and noisy; the underlying scorecard metrics already convey the result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed duplicate VERDICT line from backtesting output display.

* **Documentation**
  * Updated backtesting example in README to reflect current output format.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OctagonAI/kalshi-trading-bot-cli/pull/30)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->