### PR TITLE
fix(analyze): don't gate report generation on a tradeable last_price

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kalshi-trading-bot-cli",
-  "version": "2.1.4",
+  "version": "2.1.6",
   "description": "Kalshi Trading Bot CLI - AI-powered prediction market terminal.",
   "license": "MIT",
   "author": "Octagon AI, Inc.",

--- a/src/commands/__tests__/analyze-format.test.ts
+++ b/src/commands/__tests__/analyze-format.test.ts
@@ -11,6 +11,7 @@ function base(overrides: Partial<AnalyzeData>): AnalyzeData {
     modelRunAt: '2026-06-09 18:30 UTC',
     staleUpstream: false,
     hasModel: true,
+    hasMarketPrice: true,
     modelProb: 0.72,
     marketProb: 0.58,
     edge: 0.14,
@@ -81,6 +82,35 @@ describe('formatAnalyzeHuman — date label clarity', () => {
   test('explains that --refresh bumps Cache refreshed at', () => {
     const out = formatAnalyzeHuman(base({ fromCache: true }));
     expect(out).toContain('bumps on --refresh');
+  });
+});
+
+describe('formatAnalyzeHuman — no market price', () => {
+  test('shows "--" for market prob + edge and skips Kelly when no last price', () => {
+    const out = formatAnalyzeHuman(base({
+      hasMarketPrice: false, hasModel: true,
+      modelProb: 0.62, marketProb: 0.5,
+    }));
+    expect(out).toContain('Market Prob: --');
+    expect(out).toContain("no last traded price");
+    // Edge must NOT be computed from a placeholder
+    expect(out).toContain('Edge:        --');
+    expect(out).toContain('Confidence:  --');
+    // Model prob still renders since Octagon does have coverage
+    expect(out).toContain('Model Prob:  62.0%');
+    // Kelly block is replaced with a skip message
+    expect(out).toContain('Skipped — market has no last traded price');
+    expect(out).not.toContain('Cash Balance:');
+  });
+
+  test('shows "--" for both Model Prob and Market Prob when neither is available', () => {
+    const out = formatAnalyzeHuman(base({
+      hasMarketPrice: false, hasModel: false,
+      modelProb: 0.5, marketProb: 0.5,
+    }));
+    expect(out).toContain('Model Prob:  --');
+    expect(out).toContain('Market Prob: --');
+    expect(out).toContain('Edge:        --');
   });
 });
 

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -55,6 +55,17 @@ export interface AnalyzeData {
    * not as the 0.5 placeholder.
    */
   hasModel: boolean;
+  /**
+   * True when the Kalshi market has a `last_price` (it has actually traded).
+   * When false, market_prob/edge/Kelly cannot be computed; the formatter
+   * renders "--" for those fields and notes that the report was generated
+   * without a tradeable price reference.
+   *
+   * The Octagon report itself still loads — only the trading-side math is
+   * skipped. This is the common case for newly-listed event-level markets
+   * (e.g. World Cup quarterfinal contracts before the bracket is set).
+   */
+  hasMarketPrice: boolean;
   reportAge: string | null;
   reportId: string;
   rawReport: string;
@@ -168,10 +179,16 @@ export async function handleAnalyze(
   const market = await resolveMarket(ticker);
   const resolvedTicker = market.ticker;
   const eventTicker = market.event_ticker;
-  const marketProb = parseMarketProb(market);
-  if (marketProb === null) {
-    throw new Error(`No last traded price for ${resolvedTicker} — market may have no trades yet.`);
-  }
+  const rawMarketProb = parseMarketProb(market);
+  const hasMarketPrice = rawMarketProb !== null;
+
+  // Many event-level Kalshi tickers exist before any contract has traded
+  // (World Cup brackets, FOMC date ladders, IPO timing — there's no
+  // last_price until someone takes a side). The Octagon report path doesn't
+  // need market_prob — only the edge / Kelly / risk-gate math does. So we
+  // keep going with a neutral fallback and mark hasMarketPrice = false so
+  // the formatter renders "--" for the trading-side fields.
+  const marketProb = hasMarketPrice ? rawMarketProb! : 0.5;
 
   const invoker = createOctagonInvoker();
   const octagonClient = new OctagonClient(invoker, db, auditTrail);
@@ -230,30 +247,37 @@ export async function handleAnalyze(
     confidence: snapshot.confidence,
   });
 
-  // Kelly sizing — wrapped in try/catch for demo mode (portfolio endpoints may 401)
+  // Kelly sizing — wrapped in try/catch for demo mode (portfolio endpoints may 401).
+  // Skip Kelly entirely when there's no last_price: any sizing computed from
+  // a 50% market_prob fallback would be meaningless.
+  const emptyKelly: KellyResult = {
+    side: snapshot.edge >= 0 ? 'yes' : 'no',
+    fraction: 0,
+    adjustedFraction: 0,
+    contracts: 0,
+    dollarAmountCents: 0,
+    entryPriceCents: 0,
+    availableBankroll: 0,
+    openExposure: 0,
+    cashBalance: 0,
+    portfolioValue: 0,
+    liquidityAdjusted: false,
+  };
   let kelly: KellyResult;
-  try {
-    kelly = await kellySize({
-      edge: snapshot.edge,
-      marketProb,
-      market,
-      multiplier: getBotSetting('risk.kelly_multiplier') as number | undefined,
-      minEdgeThreshold: getBotSetting('risk.min_edge_threshold') as number | undefined,
-    });
-  } catch {
-    kelly = {
-      side: snapshot.edge >= 0 ? 'yes' : 'no',
-      fraction: 0,
-      adjustedFraction: 0,
-      contracts: 0,
-      dollarAmountCents: 0,
-      entryPriceCents: 0,
-      availableBankroll: 0,
-      openExposure: 0,
-      cashBalance: 0,
-      portfolioValue: 0,
-      liquidityAdjusted: false,
-    };
+  if (!hasMarketPrice) {
+    kelly = emptyKelly;
+  } else {
+    try {
+      kelly = await kellySize({
+        edge: snapshot.edge,
+        marketProb,
+        market,
+        multiplier: getBotSetting('risk.kelly_multiplier') as number | undefined,
+        minEdgeThreshold: getBotSetting('risk.min_edge_threshold') as number | undefined,
+      });
+    } catch {
+      kelly = { ...emptyKelly };
+    }
   }
 
   // Risk gate
@@ -292,7 +316,10 @@ export async function handleAnalyze(
   const entryPrice = (snapshot.edge > 0 ? yesAsk : noAsk);
 
   let signal: string;
-  if (existingPosition) {
+  if (!hasMarketPrice) {
+    // No tradeable price — no actionable signal. Render explicitly.
+    signal = 'no signal (market has no last traded price)';
+  } else if (existingPosition) {
     const holdDir = existingPosition.direction.toUpperCase();
     const edgeReversed =
       (existingPosition.direction === 'yes' && snapshot.edge < -0.03) ||
@@ -362,6 +389,7 @@ export async function handleAnalyze(
     modelRunAt,
     staleUpstream,
     hasModel,
+    hasMarketPrice,
     modelProb: snapshot.modelProb,
     marketProb,
     edge: snapshot.edge,
@@ -404,19 +432,25 @@ export function formatAnalyzeHuman(data: AnalyzeData): string {
   }
   lines.push('');
 
-  // Edge & Probabilities.
-  // When Octagon has no model scoring for this market (hasModel=false), render
-  // the model/edge fields as "--" instead of the 0.5 placeholder — otherwise
-  // downstream consumers (bots, dashboards) think we have a 50/50 prediction.
-  if (data.hasModel) {
-    lines.push(`  Model Prob:  ${(data.modelProb * 100).toFixed(1)}%`);
-    lines.push(`  Market Prob: ${(data.marketProb * 100).toFixed(1)}%`);
+  // Edge & Probabilities. Two independent reasons a field may be unavailable:
+  //   hasModel=false       → Octagon has no model scoring → Model Prob shows "--"
+  //   hasMarketPrice=false → Kalshi market has no last_price → Market Prob shows "--"
+  // Edge needs both. Either being false means edge/confidence/mispricing
+  // render "--" — we never show a number derived from a placeholder.
+  const modelStr = data.hasModel
+    ? `${(data.modelProb * 100).toFixed(1)}%`
+    : `--   (no Octagon model coverage for this market)`;
+  const marketStr = data.hasMarketPrice
+    ? `${(data.marketProb * 100).toFixed(1)}%`
+    : `--   (no last traded price — market hasn't traded yet)`;
+  const canComputeEdge = data.hasModel && data.hasMarketPrice;
+  lines.push(`  Model Prob:  ${modelStr}`);
+  lines.push(`  Market Prob: ${marketStr}`);
+  if (canComputeEdge) {
     lines.push(`  Edge:        ${data.edgePp} (${(data.edge * 100).toFixed(1)}%)`);
     lines.push(`  Confidence:  ${data.confidence}`);
     lines.push(`  Mispricing:  ${data.mispricingSignal}`);
   } else {
-    lines.push(`  Model Prob:  --   (no Octagon model coverage for this market)`);
-    lines.push(`  Market Prob: ${(data.marketProb * 100).toFixed(1)}%`);
     lines.push(`  Edge:        --`);
     lines.push(`  Confidence:  --`);
     lines.push(`  Mispricing:  --`);
@@ -449,22 +483,26 @@ export function formatAnalyzeHuman(data: AnalyzeData): string {
     lines.push('');
   }
 
-  // Kelly Sizing
+  // Position Sizing — only meaningful when there's a tradeable price.
   lines.push('  Position Sizing (Half-Kelly):');
-  lines.push(`    Side:         ${data.kelly.side.toUpperCase()}`);
-  lines.push(`    Cash Balance: $${(data.kelly.cashBalance / 100).toFixed(2)}`);
-  lines.push(`    Open Exposure: $${(data.kelly.openExposure / 100).toFixed(2)}`);
-  lines.push(`    Available:    $${(data.kelly.availableBankroll / 100).toFixed(2)}`);
-  lines.push(`    Contracts:    ${data.kelly.contracts}`);
-  lines.push(`    Dollar Amount: $${(data.kelly.dollarAmountCents / 100).toFixed(2)}`);
-  lines.push(`    Entry Price:  ${data.kelly.entryPriceCents}¢`);
-  lines.push(`    Kelly f*:     ${(data.kelly.fraction * 100).toFixed(1)}%`);
-  lines.push(`    Adjusted f:   ${(data.kelly.adjustedFraction * 100).toFixed(1)}%`);
-  if (data.kelly.liquidityAdjusted) {
-    lines.push('    ⚠ Liquidity-adjusted (wide spread or low volume)');
-  }
-  if (data.kelly.skippedReason) {
-    lines.push(`    ⚠ ${data.kelly.skippedReason}`);
+  if (!data.hasMarketPrice) {
+    lines.push('    ⚠ Skipped — market has no last traded price; no sizing reference available.');
+  } else {
+    lines.push(`    Side:         ${data.kelly.side.toUpperCase()}`);
+    lines.push(`    Cash Balance: $${(data.kelly.cashBalance / 100).toFixed(2)}`);
+    lines.push(`    Open Exposure: $${(data.kelly.openExposure / 100).toFixed(2)}`);
+    lines.push(`    Available:    $${(data.kelly.availableBankroll / 100).toFixed(2)}`);
+    lines.push(`    Contracts:    ${data.kelly.contracts}`);
+    lines.push(`    Dollar Amount: $${(data.kelly.dollarAmountCents / 100).toFixed(2)}`);
+    lines.push(`    Entry Price:  ${data.kelly.entryPriceCents}¢`);
+    lines.push(`    Kelly f*:     ${(data.kelly.fraction * 100).toFixed(1)}%`);
+    lines.push(`    Adjusted f:   ${(data.kelly.adjustedFraction * 100).toFixed(1)}%`);
+    if (data.kelly.liquidityAdjusted) {
+      lines.push('    ⚠ Liquidity-adjusted (wide spread or low volume)');
+    }
+    if (data.kelly.skippedReason) {
+      lines.push(`    ⚠ ${data.kelly.skippedReason}`);
+    }
   }
   lines.push('');
 


### PR DESCRIPTION
User-reported bug on KXWCROUND-26QUAR and similar World Cup event-level markets: analyze threw "No last traded price for {ticker} — market may have no trades yet" before ever attempting to fetch or refresh the Octagon report. The check was at analyze.ts:171-174, immediately after resolveMarket. Cause is intermittent because resolveMarket picks the top-volume open child contract from an event ticker — if that contract happens to have no last_price (common for newly-listed bracket contracts before anyone takes a side), the entire pipeline dies before Octagon is called.

The Octagon report path doesn't actually need market_prob. Only the edge / Kelly / risk-gate math does. So we now:

  - Remove the throw. parseMarketProb still returns null, but we keep going with hasMarketPrice = false and a 0.5 neutral fallback for downstream arithmetic.
  - Fetch (and force-refresh, if requested) the Octagon report regardless.
  - Skip Kelly entirely when hasMarketPrice is false (any sizing computed from a 0.5 placeholder would be meaningless).
  - In the formatter: Market Prob: --  (no last traded price — market hasn't traded yet)
      Edge:        --
      Confidence:  --
      Mispricing:  --
      Position Sizing (Half-Kelly):
        ⚠ Skipped — market has no last traded price; no sizing reference available.
    Model Prob still renders when Octagon has scored the event.
    Signal becomes "no signal (market has no last traded price)".

AnalyzeData gains hasMarketPrice: boolean. The --json envelope exposes the flag so bots can branch on it without parsing the human output.

Tests: 279 passing (+2 new — "--" rendering when no last price, both flags false produce both "--" lines). Typecheck clean. Live-verified end-to-end on KXWCROUND-26QUAR (resolved to KXWCROUND-26QUAR-MEX, which happened to have a price today and ran the full pipeline) and via the existing analyze-format unit tests for the no-price branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of markets without a last traded price; the analyze command now gracefully displays `--` for unavailable metrics and skips position sizing calculations instead of failing.

* **Chores**
  * Version bumped to 2.1.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->