### PR TITLE
feat(trust): add `trust` command for Octagon Trader Trust scorecard; …

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Type help for commands, or just ask a question.
 | `series` / `series <ticker>` | Kalshi series rollup (24h vol, market count) |
 | `series candles <ticker>` | Series-level NAV (basket of top sub-markets) |
 | `catalysts upcoming --days N` | Markets closing in the next N days, grouped by week |
+| `trust <event_ticker>` | Trader Trust scorecard — per-market integrity scores (table view) |
+| `trust <event> --market <market>` | Single-market Trader Trust detail card (use `--verbose` for evidence) |
 | `themes` (registry) | Editorial narrative buckets — list/show/import/create/delete/add-series |
 | `themes report` | 25-theme dashboard with SEO + liquidity |
 | `themes audit` | Flag dead themes (high SEO + zero volume) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kalshi-trading-bot-cli",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Kalshi Trading Bot CLI - AI-powered prediction market terminal.",
   "license": "MIT",
   "author": "Octagon AI, Inc.",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -360,6 +360,7 @@ export async function runCli(options?: { forceSetup?: boolean }) {
       { value: 'correlate', label: 'correlate', description: 'Pairwise correlation matrix' },
       { value: 'basket', label: 'basket', description: 'Build / backtest / size baskets' },
       { value: 'events', label: 'events', description: 'Octagon events (event ↔ outcome ladder)' },
+      { value: 'trust', label: 'trust', description: 'Trader Trust scorecard (per-market integrity scores)' },
       { value: 'series', label: 'series', description: 'Series rollup / NAV' },
       { value: 'catalysts', label: 'catalysts', description: 'Upcoming market closes by week' },
       { value: 'themes', label: 'themes', description: 'Editorial narrative registry + dashboard' },
@@ -430,6 +431,7 @@ export async function runCli(options?: { forceSetup?: boolean }) {
     { name: 'peers', description: 'Find markets in the same cluster as a ticker', getArgumentCompletions: usageHint('<ticker> [--behavioral] [--limit N] [--show-cluster]', 'e.g. KXBTCD-26DEC31-T100000 --limit 20') },
     { name: 'correlate', description: 'Pairwise correlation matrix (2-100 tickers)', getArgumentCompletions: usageHint('<ticker1> <ticker2> [...] [--window-days N]', 'e.g. KXA KXB KXC --window-days 90') },
     { name: 'events', description: 'Octagon events — outcome ladder per event', getArgumentCompletions: usageHint('<event_ticker> | --category Politics | --min-volume 10000', 'e.g. KXFEDCHAIRNOM-29 to drill in') },
+    { name: 'trust', description: 'Trader Trust scorecard (per-market integrity scores)', getArgumentCompletions: usageHint('<event_ticker> [--market <market_ticker>] [--verbose]', 'e.g. KXMENWORLDCUP-26 --market KXMENWORLDCUP-26-FR') },
     { name: 'series', description: 'Kalshi series rollup (24h vol, market count)', getArgumentCompletions: (typed: string): AutocompleteItem[] | null => {
       const opts = [
         { value: '<series_ticker>', label: '<series_ticker>', description: 'Drill into one series (e.g. KXBTCD)' },

--- a/src/commands/__tests__/trust.test.ts
+++ b/src/commands/__tests__/trust.test.ts
@@ -1,0 +1,253 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import type { ParsedArgs } from '../parse-args.js';
+import { handleTrust, formatTrustHuman, type TraderTrustCard, type TrustResult } from '../trust.js';
+import type { CLIResponse } from '../json.js';
+
+function makeArgs(o: Partial<ParsedArgs>): ParsedArgs {
+  return {
+    subcommand: 'trust',
+    positionalArgs: [],
+    json: false,
+    live: false, refresh: false, report: false, dryRun: false, verbose: false,
+    performance: false, resolved: false, unresolved: false,
+    behavioral: false, ranked: false, showCluster: false, activeOnly: false,
+    cells: false, autoProbs: false,
+    parseErrors: [],
+    ...o,
+  };
+}
+
+function makeCard(overrides?: Partial<TraderTrustCard>): TraderTrustCard {
+  const score = (value: number) => ({
+    value,
+    label: value >= 70 ? 'High' : value >= 40 ? 'Moderate' : 'Low',
+    drivers: [
+      { name: 'depth_score', sub_score: value, points: 12.5 },
+      { name: 'spread_pp', sub_score: value - 5, points: 7.3 },
+      { name: 'fill_consistency', sub_score: value - 10, points: 4.2 },
+    ],
+    evidence: [{ metric: 'avg_spread_cents', value: 1.2 }],
+    confidence: 'high' as const,
+    data_freshness: 'point_in_time' as const,
+  });
+  return {
+    calculation_version: 'trust_dashboard_v1.0',
+    computed_at: '2026-06-22T15:30:00Z',
+    event_ticker: 'KX-EVT',
+    rollup: { median_trader_trust: 70, min_trader_trust: 55, markets_scored: 3 },
+    markets: [
+      {
+        market_ticker: 'KX-EVT-A',
+        title: 'France',
+        is_primary: true,
+        scores: {
+          trader_trust: score(85),
+          liquidity_quality: score(80),
+          move_quality: score(75),
+          market_avoid: score(15),
+          quote_risk: score(20),
+          resolution_risk: score(90),
+        },
+      },
+      {
+        market_ticker: 'KX-EVT-B',
+        title: 'Brazil',
+        is_primary: false,
+        scores: {
+          trader_trust: score(55),
+          liquidity_quality: score(50),
+          move_quality: score(60),
+          market_avoid: score(30),
+          quote_risk: score(40),
+          resolution_risk: score(70),
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+type FetchHandler = (url: string, init?: RequestInit) => Response | Promise<Response>;
+function installFetchMock(handler: FetchHandler): void {
+  globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+    return handler(s, init);
+  }) as unknown as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+describe('handleTrust', () => {
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    process.env.OCTAGON_API_KEY = 'sk_test';
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.OCTAGON_API_KEY;
+  });
+
+  test('missing event ticker → error', async () => {
+    installFetchMock(() => jsonResponse({}));
+    const resp = await handleTrust(makeArgs({ positionalArgs: [] }));
+    expect(resp.ok).toBe(false);
+    if (resp.ok) return;
+    expect(resp.error?.code).toBe('MISSING_EVENT');
+  });
+
+  test('event 404 → EVENT_NOT_FOUND', async () => {
+    installFetchMock(() => new Response('{}', { status: 404 }));
+    const resp = await handleTrust(makeArgs({ positionalArgs: ['KX-EVT'] }));
+    expect(resp.ok).toBe(false);
+    if (resp.ok) return;
+    expect(resp.error?.code).toBe('EVENT_NOT_FOUND');
+  });
+
+  test('trader_trust_json null → NO_SCORECARD (graceful, not crash)', async () => {
+    installFetchMock(() => jsonResponse({
+      event_ticker: 'KX-EVT', name: 'Test', trader_trust_json: null,
+    }));
+    const resp = await handleTrust(makeArgs({ positionalArgs: ['KX-EVT'] }));
+    expect(resp.ok).toBe(false);
+    if (resp.ok) return;
+    expect(resp.error?.code).toBe('NO_SCORECARD');
+    expect(resp.error?.message).toMatch(/no trust scorecard/i);
+  });
+
+  test('malformed trader_trust_json → PARSE_ERROR', async () => {
+    installFetchMock(() => jsonResponse({
+      event_ticker: 'KX-EVT', name: 'Test', trader_trust_json: 'not json',
+    }));
+    const resp = await handleTrust(makeArgs({ positionalArgs: ['KX-EVT'] }));
+    expect(resp.ok).toBe(false);
+    if (resp.ok) return;
+    expect(resp.error?.code).toBe('PARSE_ERROR');
+  });
+
+  test('valid event returns table result', async () => {
+    const card = makeCard();
+    installFetchMock(() => jsonResponse({
+      event_ticker: 'KX-EVT', name: 'Test event',
+      trader_trust_json: JSON.stringify(card),
+    }));
+    const resp = await handleTrust(makeArgs({ positionalArgs: ['KX-EVT'] }));
+    expect(resp.ok).toBe(true);
+    if (!resp.ok) return;
+    if (resp.data.kind !== 'table') throw new Error();
+    expect(resp.data.card.markets).toHaveLength(2);
+    expect(resp.data.event_name).toBe('Test event');
+  });
+
+  test('--market drills into one market', async () => {
+    const card = makeCard();
+    installFetchMock(() => jsonResponse({
+      event_ticker: 'KX-EVT', name: 'Test',
+      trader_trust_json: JSON.stringify(card),
+    }));
+    const resp = await handleTrust(makeArgs({ positionalArgs: ['KX-EVT'], market: 'KX-EVT-A' }));
+    expect(resp.ok).toBe(true);
+    if (!resp.ok) return;
+    if (resp.data.kind !== 'detail') throw new Error();
+    expect(resp.data.market.market_ticker).toBe('KX-EVT-A');
+    expect(resp.data.verbose).toBe(false);
+  });
+
+  test('--market with unknown ticker → MARKET_NOT_IN_SCORECARD', async () => {
+    const card = makeCard();
+    installFetchMock(() => jsonResponse({
+      event_ticker: 'KX-EVT', trader_trust_json: JSON.stringify(card),
+    }));
+    const resp = await handleTrust(makeArgs({ positionalArgs: ['KX-EVT'], market: 'KX-EVT-Z' }));
+    expect(resp.ok).toBe(false);
+    if (resp.ok) return;
+    expect(resp.error?.code).toBe('MARKET_NOT_IN_SCORECARD');
+  });
+
+  test('case-insensitive ticker matching for --market', async () => {
+    const card = makeCard();
+    installFetchMock(() => jsonResponse({
+      event_ticker: 'KX-EVT', trader_trust_json: JSON.stringify(card),
+    }));
+    const resp = await handleTrust(makeArgs({ positionalArgs: ['kx-evt'], market: 'kx-evt-a' }));
+    expect(resp.ok).toBe(true);
+  });
+
+  test('--verbose propagates into detail result', async () => {
+    const card = makeCard();
+    installFetchMock(() => jsonResponse({
+      event_ticker: 'KX-EVT', trader_trust_json: JSON.stringify(card),
+    }));
+    const resp = await handleTrust(makeArgs({ positionalArgs: ['KX-EVT'], market: 'KX-EVT-A', verbose: true }));
+    expect(resp.ok).toBe(true);
+    if (!resp.ok || resp.data.kind !== 'detail') throw new Error();
+    expect(resp.data.verbose).toBe(true);
+  });
+});
+
+describe('formatTrustHuman', () => {
+  test('table view contains rollup, header, both markets, and legend', () => {
+    const card = makeCard();
+    const result: TrustResult = { kind: 'table', card, event_name: 'Test event' };
+    const out = formatTrustHuman(result);
+    expect(out).toContain('Trader Trust scorecard for KX-EVT');
+    expect(out).toContain('Test event');
+    expect(out).toContain('Median trust 70');
+    expect(out).toContain('trust_dashboard_v1.0');
+    expect(out).toContain('KX-EVT-A');
+    expect(out).toContain('KX-EVT-B');
+    expect(out).toContain('France');
+    expect(out).toContain('Brazil');
+    // is_primary mark
+    expect(out).toContain('*');
+    // Legend mentions both directions of "good"
+    expect(out).toMatch(/Higher is (better|worse)/i);
+  });
+
+  test('table sorted by liquidity_quality desc', () => {
+    const card = makeCard();
+    // Make B have higher liquidity than A
+    card.markets[0].scores.liquidity_quality.value = 30;
+    card.markets[1].scores.liquidity_quality.value = 90;
+    const out = formatTrustHuman({ kind: 'table', card, event_name: null });
+    const aIdx = out.indexOf('KX-EVT-A');
+    const bIdx = out.indexOf('KX-EVT-B');
+    expect(bIdx).toBeGreaterThan(0);
+    expect(bIdx).toBeLessThan(aIdx);
+  });
+
+  test('detail view shows each score with label and top drivers', () => {
+    const card = makeCard();
+    const out = formatTrustHuman({ kind: 'detail', card, market: card.markets[0], verbose: false });
+    expect(out).toContain('KX-EVT-A');
+    expect(out).toContain('(primary)');
+    // Each of the six score keys appears
+    expect(out).toContain('Trust');
+    expect(out).toContain('Liquidity');
+    expect(out).toContain('Move');
+    expect(out).toContain('Avoid');
+    expect(out).toContain('Quote');
+    expect(out).toContain('Resol');
+    // Driver names present
+    expect(out).toContain('depth_score');
+    expect(out).toContain('spread_pp');
+    expect(out).toContain('fill_consistency');
+    // Risk-metric annotation on market_avoid / quote_risk
+    expect(out).toContain('risk metric');
+    // point_in_time → "as of report time" annotation
+    expect(out).toContain('as of report time');
+    // Evidence is NOT shown without --verbose
+    expect(out).not.toContain('Evidence:');
+  });
+
+  test('detail view with --verbose surfaces evidence + confidence + freshness', () => {
+    const card = makeCard();
+    const out = formatTrustHuman({ kind: 'detail', card, market: card.markets[0], verbose: true });
+    expect(out).toContain('Evidence:');
+    expect(out).toContain('avg_spread_cents: 1.2');
+    expect(out).toContain('Confidence: high');
+    expect(out).toContain('Freshness: point_in_time');
+  });
+});

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -34,6 +34,7 @@ import { handleBasket, formatBasketHuman } from './basket.js';
 import { searchKalshiMarkets, getMarketsWithEdge } from '../scan/octagon-kalshi-api.js';
 import { formatMarketSearchHuman, formatMarketsWithEdgeHuman } from './search-remote.js';
 import { handleEvents, formatEventsHuman } from './events.js';
+import { handleTrust, formatTrustHuman } from './trust.js';
 import { handleSeries, formatSeriesHuman } from './series.js';
 import { handleEditorialThemes, formatEditorialThemesHuman } from './editorial-themes.js';
 import { handleCatalysts, formatCatalystsHuman } from './catalysts.js';
@@ -494,6 +495,20 @@ export async function dispatch(args: ParsedArgs): Promise<void> {
         console.log(formatSeriesHuman(resp.data));
       } else {
         console.error(resp.error?.message ?? 'series failed');
+      }
+      process.exit(resp.ok ? ExitCode.SUCCESS : ExitCode.USER_ERROR);
+      return;
+    }
+
+    // ─── trust (Trader Trust scorecard) ────────────────────────────────
+    if (resolved.canonical === 'trust') {
+      const resp = await handleTrust(args);
+      if (json) {
+        console.log(JSON.stringify(resp));
+      } else if (resp.ok) {
+        console.log(formatTrustHuman(resp.data));
+      } else {
+        console.error(resp.error?.message ?? 'trust failed');
       }
       process.exit(resp.ok ? ExitCode.SUCCESS : ExitCode.USER_ERROR);
       return;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -249,6 +249,36 @@ Flags:
 
 Output ranks pairs ascending by correlation — most-uncorrelated first.`,
 
+    trust: `**${p}trust** — Trader Trust scorecard (market-integrity metrics)
+
+${p}trust <event_ticker>                       Table across all markets in the event
+${p}trust <event_ticker> --market <market>     Single-market detail card
+${p}trust <event_ticker> --market <market> --verbose
+                                            Include raw evidence + confidence/freshness
+
+Six per-market scores (each 0-100), produced by Octagon's deterministic
+Trader Trust calculation:
+
+  trader_trust       Overall composite                      (higher = better)
+  liquidity_quality  Depth/spread/fill behavior             (higher = better)
+  move_quality       Price-move plausibility                (higher = better)
+  resolution_risk    Resolution clarity (higher = clearer)  (higher = better)
+  market_avoid       Avoidance signal                       (higher = WORSE)
+  quote_risk         Quote-side risk                        (higher = WORSE)
+
+Flags:
+  --market <ticker>   Drill into one market in the event
+  --verbose           Show evidence (raw metrics), confidence, data freshness
+  --json              JSON envelope output
+
+Notes:
+  - When trader_trust_json is null (older reports), prints "no trust scorecard for
+    this event yet" — not an error.
+  - Higher-is-better vs. higher-is-worse semantics differ per score; tables and
+    detail views color and annotate accordingly.
+  - "(as of report time)" is shown for scores whose data_freshness is
+    point_in_time (e.g. quote_risk, liquidity_quality on snapshot reports).`,
+
     events: `**${p}events** — Octagon event rollups (event ↔ outcome ladder)
 
 ${p}events                              List events sorted by total_volume
@@ -426,6 +456,8 @@ Discovery:
   series <SERIES>               Sub-markets in one series
   series candles <SERIES>       Series NAV (basket of top sub-markets)
   catalysts upcoming --days 30  Markets closing soon, grouped by week
+  trust <event_ticker>          Trader Trust scorecard (table across markets)
+  trust <event> --market <mkt>  Single-market trust detail card
   watch <ticker>                Live price/orderbook feed
   watch --theme <theme>         Continuous theme scan (Ctrl+C to stop)
   watch --refresh               Force index rebuild before watching
@@ -503,6 +535,8 @@ Discovery:
   /series <SERIES>               Sub-markets in one series
   /series candles <SERIES>       Series NAV (basket of top sub-markets)
   /catalysts upcoming --days 30  Markets closing soon, grouped by week
+  /trust <event_ticker>          Trader Trust scorecard (table across markets)
+  /trust <event> --market <mkt>  Single-market trust detail card
   /watch <ticker>                Live price/orderbook feed
   /watch --theme <theme>         Continuous theme scan (Esc to stop)
   /watch --refresh               Force index rebuild before watching

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -37,6 +37,7 @@ import { handlePeers, formatPeersHuman } from './peers.js';
 import { handleCorrelate, formatCorrelationHuman } from './correlate.js';
 import { handleBasket, formatBasketHuman } from './basket.js';
 import { handleEvents, formatEventsHuman } from './events.js';
+import { handleTrust, formatTrustHuman } from './trust.js';
 import { handleSeries, formatSeriesHuman } from './series.js';
 import { handleEditorialThemes, formatEditorialThemesHuman } from './editorial-themes.js';
 import { handleCatalysts, formatCatalystsHuman } from './catalysts.js';
@@ -240,6 +241,16 @@ export async function handleSlashCommand(input: string): Promise<CommandResult |
         asyncFollowUp: async () => {
           const resp = await handleEvents(parsed);
           return resp.ok ? formatEventsHuman(resp.data) : (resp.error?.message ?? 'events failed');
+        },
+      };
+    }
+    case 'trust': {
+      const parsed = parseArgs(['trust', ...args]);
+      return {
+        output: 'Fetching Trader Trust scorecard...',
+        asyncFollowUp: async () => {
+          const resp = await handleTrust(parsed);
+          return resp.ok ? formatTrustHuman(resp.data) : (resp.error?.message ?? 'trust failed');
         },
       };
     }

--- a/src/commands/parse-args.ts
+++ b/src/commands/parse-args.ts
@@ -11,6 +11,8 @@ const SUBCOMMANDS = [
   'similar', 'clusters', 'peers', 'correlate', 'basket',
   // Octagon events + Kalshi series rollup + editorial themes registry
   'events', 'series', 'catalysts',
+  // Trader Trust scorecard
+  'trust',
 ] as const;
 
 export type Subcommand = (typeof SUBCOMMANDS)[number];
@@ -76,6 +78,8 @@ export interface ParsedArgs {
   cells: boolean;          // include_cell_detail for correlate
   autoProbs: boolean;      // basket size: auto-fetch leg probabilities via markets/edge
   daysToClose?: number;    // ergonomic shortcut: close_before = now + N days
+  /** --market <ticker>: drill into a specific market within an event (trust). */
+  market?: string;
   parseErrors: string[];
 }
 
@@ -137,6 +141,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
   let cells = false;
   let autoProbs = false;
   let daysToClose: number | undefined;
+  let market: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -421,6 +426,12 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
       cells = true;
     } else if (arg === '--auto-probs') {
       autoProbs = true;
+    } else if (arg === '--market') {
+      if (i + 1 >= argv.length) {
+        parseErrors.push('--market requires a value (a Kalshi market ticker)');
+      } else {
+        market = argv[++i].toUpperCase();
+      }
     } else if (arg === '--days-to-close' || arg === '--max-dte') {
       const raw = argv[++i];
       if (raw != null) {
@@ -457,7 +468,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
     topK, behavioral, ranked, labelContains, closeBefore, windowDays, correlationInterval, timeframe,
     weights, bankroll, kellyMultiplier, n, maxPerCluster, maxCorrelation, minReturn, seriesTicker,
     sortBy, probabilities, tickers, query, showCluster, aggregateBy, activeOnly,
-    seriesPrefix, sides, cells, autoProbs, daysToClose,
+    seriesPrefix, sides, cells, autoProbs, daysToClose, market,
     parseErrors,
   };
 }

--- a/src/commands/trust.ts
+++ b/src/commands/trust.ts
@@ -1,0 +1,249 @@
+/**
+ * Trader Trust scorecard.
+ *
+ * Surfaces Octagon's per-market market-integrity score from the new
+ * `trader_trust_json` field on /v1/prediction-markets/events/{event_ticker}.
+ *
+ * Two views:
+ *   - kalshi trust <event-ticker>                  → table across all markets
+ *   - kalshi trust <event-ticker> --market <mkt>   → single-market detail card
+ *
+ * Six per-market scores, each in [0, 100]. Their direction-of-good differs:
+ *
+ *   HIGHER IS GOOD (green at top, red at bottom):
+ *     - trader_trust         (overall composite)
+ *     - liquidity_quality
+ *     - move_quality
+ *     - resolution_risk      (despite the name, the score itself is
+ *                             "resolution clarity" — higher = better; the
+ *                             label string explains the value)
+ *
+ *   HIGHER IS BAD (red at top, green at bottom):
+ *     - market_avoid
+ *     - quote_risk
+ *
+ * trader_trust_json is null on reports generated before this calculation
+ * shipped; the handler returns a clear "no scorecard yet" error rather than
+ * crashing.
+ */
+import { wrapSuccess, wrapError } from './json.js';
+import type { CLIResponse } from './json.js';
+import type { ParsedArgs } from './parse-args.js';
+import { fetchOctagonEventDirect } from '../scan/octagon-events-api.js';
+import { formatTable } from './scan-formatters.js';
+import { theme } from '../theme.js';
+
+/** A single contributor to a score; the "why" behind the number. */
+export interface TrustDriver {
+  name: string;
+  sub_score: number;
+  points: number;
+}
+
+/** A raw metric backing the score; shown with --verbose. */
+export interface TrustEvidence {
+  metric: string;
+  value: unknown;
+}
+
+export interface TrustScore {
+  value: number;        // 0-100
+  label: string;
+  drivers: TrustDriver[];
+  evidence: TrustEvidence[];
+  confidence: 'low' | 'medium' | 'high';
+  data_freshness: 'current' | 'point_in_time';
+}
+
+export interface TrustMarket {
+  market_ticker: string;
+  title: string;
+  is_primary: boolean;
+  scores: {
+    trader_trust: TrustScore;
+    liquidity_quality: TrustScore;
+    market_avoid: TrustScore;
+    move_quality: TrustScore;
+    quote_risk: TrustScore;
+    resolution_risk: TrustScore;
+  };
+}
+
+export interface TraderTrustCard {
+  calculation_version: string;
+  computed_at: string;
+  event_ticker: string;
+  rollup: {
+    median_trader_trust: number;
+    min_trader_trust: number;
+    markets_scored: number;
+  };
+  markets: TrustMarket[];
+}
+
+/** Set of scores where higher is bad (risk metrics). Used by the colorizer. */
+const HIGHER_IS_BAD: ReadonlySet<keyof TrustMarket['scores']> = new Set([
+  'market_avoid',
+  'quote_risk',
+]);
+
+/** Color a 0-100 score according to its semantic direction. */
+function colorScore(value: number, key: keyof TrustMarket['scores']): string {
+  // Normalize so high = good for the color comparison.
+  const goodness = HIGHER_IS_BAD.has(key) ? 100 - value : value;
+  const str = value.toFixed(0).padStart(3);
+  if (goodness >= 70) return theme.success(str);
+  if (goodness >= 40) return theme.warning(str);
+  return theme.error(str);
+}
+
+/** Output shape for both table and detail views (machine-readable). */
+export type TrustResult =
+  | { kind: 'table'; card: TraderTrustCard; event_name: string | null }
+  | { kind: 'detail'; card: TraderTrustCard; market: TrustMarket; verbose: boolean };
+
+export async function handleTrust(args: ParsedArgs): Promise<CLIResponse<TrustResult>> {
+  const eventTicker = args.positionalArgs[0]?.toUpperCase();
+  if (!eventTicker) {
+    return wrapError('trust', 'MISSING_EVENT', 'Usage: trust <event_ticker> [--market <market_ticker>] [--verbose]');
+  }
+
+  let event;
+  try {
+    event = await fetchOctagonEventDirect(eventTicker);
+  } catch (err) {
+    return wrapError('trust', 'OCTAGON_ERROR', err instanceof Error ? err.message : String(err));
+  }
+  if (!event) {
+    return wrapError('trust', 'EVENT_NOT_FOUND', `No Octagon record for event ${eventTicker}.`);
+  }
+  if (!event.trader_trust_json) {
+    return wrapError(
+      'trust',
+      'NO_SCORECARD',
+      `No trust scorecard for ${eventTicker} yet. The Trader Trust calculation may not have run for this event — try again after the next Octagon refresh.`,
+    );
+  }
+
+  let card: TraderTrustCard;
+  try {
+    card = JSON.parse(event.trader_trust_json) as TraderTrustCard;
+  } catch (err) {
+    return wrapError(
+      'trust',
+      'PARSE_ERROR',
+      `Octagon returned malformed trader_trust_json for ${eventTicker}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!Array.isArray(card.markets) || card.markets.length === 0) {
+    return wrapError('trust', 'EMPTY_SCORECARD', `Trust scorecard for ${eventTicker} has no markets.`);
+  }
+
+  // Single-market detail view
+  if (args.market) {
+    const wanted = args.market.toUpperCase();
+    const market = card.markets.find((m) => m.market_ticker.toUpperCase() === wanted);
+    if (!market) {
+      return wrapError(
+        'trust',
+        'MARKET_NOT_IN_SCORECARD',
+        `Market ${wanted} is not in the trust scorecard for ${eventTicker}. Run \`trust ${eventTicker}\` to see the available markets.`,
+      );
+    }
+    return wrapSuccess('trust', { kind: 'detail', card, market, verbose: args.verbose });
+  }
+
+  return wrapSuccess('trust', { kind: 'table', card, event_name: event.name ?? null });
+}
+
+export function formatTrustHuman(result: TrustResult): string {
+  if (result.kind === 'table') return formatTrustTable(result.card, result.event_name);
+  return formatTrustDetail(result.card, result.market, result.verbose);
+}
+
+const SCORE_KEYS: Array<keyof TrustMarket['scores']> = [
+  'trader_trust',
+  'liquidity_quality',
+  'move_quality',
+  'market_avoid',
+  'quote_risk',
+  'resolution_risk',
+];
+
+const SCORE_HEADER_LABELS: Record<keyof TrustMarket['scores'], string> = {
+  trader_trust: 'Trust',
+  liquidity_quality: 'Liquidity',
+  move_quality: 'Move',
+  market_avoid: 'Avoid↑',
+  quote_risk: 'Quote↑',
+  resolution_risk: 'Resol.',
+};
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + '…' : s;
+}
+
+function formatTrustTable(card: TraderTrustCard, eventName: string | null): string {
+  const lines: string[] = [];
+  const title = eventName ? ` — ${eventName}` : '';
+  lines.push(`Trader Trust scorecard for ${card.event_ticker}${title}`);
+  lines.push(
+    `  Median trust ${card.rollup.median_trader_trust}  ·  Min ${card.rollup.min_trader_trust}  ·  ${card.rollup.markets_scored} markets scored`,
+  );
+  lines.push(`  Calculation ${card.calculation_version}  ·  Computed ${card.computed_at.slice(0, 16).replace('T', ' ')} UTC`);
+  lines.push('');
+
+  // Sort by liquidity_quality desc; the most active markets surface first.
+  const sorted = card.markets.slice().sort((a, b) => b.scores.liquidity_quality.value - a.scores.liquidity_quality.value);
+
+  const headers = ['', 'Market', 'Title', ...SCORE_KEYS.map((k) => SCORE_HEADER_LABELS[k])];
+  const rows: string[][] = sorted.map((m) => [
+    m.is_primary ? '*' : ' ',
+    m.market_ticker,
+    truncate(m.title, 30),
+    ...SCORE_KEYS.map((k) => colorScore(m.scores[k].value, k)),
+  ]);
+  lines.push(formatTable(headers, rows));
+  lines.push('');
+  lines.push(theme.muted('  * = primary outcome.  Higher is better for Trust/Liquidity/Move/Resol.; Avoid↑ and Quote↑ are risk metrics (higher = worse).'));
+  lines.push(theme.muted(`  Drill into one market: trust ${card.event_ticker} --market <market_ticker> [--verbose]`));
+  return lines.join('\n');
+}
+
+function formatTrustDetail(card: TraderTrustCard, market: TrustMarket, verbose: boolean): string {
+  const lines: string[] = [];
+  const primaryMark = market.is_primary ? ' (primary)' : '';
+  lines.push(`Trader Trust — ${market.market_ticker}${primaryMark}`);
+  lines.push(`  ${market.title}`);
+  lines.push(`  Event ${card.event_ticker}  ·  Calculation ${card.calculation_version}  ·  Computed ${card.computed_at.slice(0, 16).replace('T', ' ')} UTC`);
+  lines.push('');
+
+  for (const key of SCORE_KEYS) {
+    const score = market.scores[key];
+    const valueStr = colorScore(score.value, key);
+    const risk = HIGHER_IS_BAD.has(key) ? ' (risk metric — higher is worse)' : '';
+    const freshness = score.data_freshness === 'point_in_time' ? ' (as of report time)' : '';
+    lines.push(`  ${SCORE_HEADER_LABELS[key].padEnd(10)}  ${valueStr}/100  ${theme.muted(score.label)}${risk}${freshness}`);
+    const topDrivers = score.drivers.slice(0, 3);
+    for (const d of topDrivers) {
+      const sign = d.points >= 0 ? '+' : '';
+      lines.push(`      • ${d.name}  ${theme.muted(`(sub ${d.sub_score.toFixed(0)}, ${sign}${d.points.toFixed(1)} pts)`)}`);
+    }
+    if (verbose && score.evidence.length > 0) {
+      lines.push(theme.muted(`      Evidence:`));
+      for (const e of score.evidence) {
+        lines.push(theme.muted(`        ${e.metric}: ${formatEvidenceValue(e.value)}`));
+      }
+      lines.push(theme.muted(`      Confidence: ${score.confidence}  ·  Freshness: ${score.data_freshness}`));
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function formatEvidenceValue(v: unknown): string {
+  if (v === null || v === undefined) return '—';
+  if (typeof v === 'number') return v.toString();
+  if (typeof v === 'string') return v;
+  try { return JSON.stringify(v); } catch { return String(v); }
+}

--- a/src/components/intro.ts
+++ b/src/components/intro.ts
@@ -72,6 +72,7 @@ export class IntroComponent extends Container {
     this.addChild(new Text(cmd('/clusters') + '[--ranked|--behavioral]  Browse thematic & behavioral clusters', 0, 0));
     this.addChild(new Text(cmd('/peers') + '<ticker>  Markets in the same cluster', 0, 0));
     this.addChild(new Text(cmd('/events') + '[ticker]  Octagon events + outcome ladder', 0, 0));
+    this.addChild(new Text(cmd('/trust') + '<event_ticker>  Trader Trust scorecard (per-market integrity)', 0, 0));
     this.addChild(new Text(cmd('/series') + '[ticker]  Series rollup; /series candles <SERIES> for NAV', 0, 0));
     this.addChild(new Text(cmd('/themes') + 'list|show|report|audit|overlap  Editorial narrative registry', 0, 0));
     this.addChild(new Text(cmd('/catalysts') + 'upcoming --days N  Markets closing soon, grouped by week', 0, 0));

--- a/src/scan/octagon-events-api.ts
+++ b/src/scan/octagon-events-api.ts
@@ -36,6 +36,15 @@ export interface OctagonEventEntry {
   current_state_summary_richtext?: string;
   short_answer_richtext?: string;
   executive_summary_richtext?: string;
+  /**
+   * Trader Trust scorecard fields (added in calculation_version v1.0+).
+   * Null on reports generated before this shipped — callers must guard.
+   */
+  trader_trust_subtitle?: string | null;
+  /** Pre-rendered HTML; the CLI ignores this and reads trader_trust_json. */
+  trader_trust_richtext?: string | null;
+  /** JSON-encoded string. See TraderTrustCard in src/commands/trust.ts. */
+  trader_trust_json?: string | null;
 }
 
 interface EventsPage {
@@ -85,6 +94,33 @@ export async function fetchOctagonEventsPage(opts?: {
     next_cursor: page.next_cursor ?? null,
     has_more: !!page.has_more,
   };
+}
+
+/**
+ * Look up a single event by ticker via the dedicated endpoint
+ * GET /v1/prediction-markets/events/{event_ticker}. Returns null on 404.
+ * Cheaper than `fetchOctagonEventByTicker` which scans paginated pages.
+ */
+export async function fetchOctagonEventDirect(eventTicker: string): Promise<OctagonEventEntry | null> {
+  const apiKey = process.env.OCTAGON_API_KEY;
+  if (!apiKey) throw new Error('OCTAGON_API_KEY not set');
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  let resp: Response;
+  try {
+    resp = await fetch(`${EVENTS_API_BASE}/prediction-markets/events/${encodeURIComponent(eventTicker)}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+  if (resp.status === 404) return null;
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '');
+    throw new Error(`Octagon event lookup ${resp.status}: ${body.slice(0, 200)}`);
+  }
+  return (await resp.json()) as OctagonEventEntry;
 }
 
 /**


### PR DESCRIPTION
…bump 2.1.9

Surfaces Octagon's new market-integrity scorecard exposed on GET /v1/prediction-markets/events/{event_ticker} via the `trader_trust_json` field. Per-market view (six 0-100 scores) with sane null-handling for older reports that predate the calculation.

Two surfaces:

  kalshi trust <event_ticker>
    Table across all markets in the event, one row per market, sorted by
    liquidity_quality desc. Header carries the rollup (median trust, min
    trust, markets_scored) plus calculation_version + computed_at.
    is_primary marker as "*" in the leading column.

  kalshi trust <event> --market <market> [--verbose]
    Single-market detail card: each score with value/100 + label + top
    3 drivers (the "why"). --verbose adds raw evidence, confidence
    ('low'/'medium'/'high'), and data_freshness ('current'/'point_in_time').

Color semantics (direction-of-good differs per score):
  HIGHER = good (green→red):  trader_trust, liquidity_quality,
                              move_quality, resolution_risk
  HIGHER = bad  (red→green):  market_avoid, quote_risk
  The detail view annotates risk metrics inline ("risk metric — higher
  is worse") and tags point_in_time scores with "(as of report time)".

Implementation:
  - src/scan/octagon-events-api.ts: extended OctagonEventEntry with trader_trust_{subtitle,richtext,json}. Added fetchOctagonEventDirect() using GET /events/{ticker} (404 → null). Existing fetchOctagonEventByTicker (paginated scan) preserved.
  - src/commands/trust.ts: new handler + formatter. Parses trader_trust_json (string), branches on --market for detail view. Errors: MISSING_EVENT, EVENT_NOT_FOUND, NO_SCORECARD (null json — graceful "no scorecard yet"), PARSE_ERROR (malformed), EMPTY_SCORECARD (empty markets), MARKET_NOT_IN_SCORECARD.
  - parse-args: added 'trust' to SUBCOMMANDS, new --market <ticker> flag with bounds-checked value (matches --universe / --fees pattern).
  - dispatch.ts + index.ts: wired into both CLI and slash paths.
  - help.ts, cli.ts (slashCommands + autocomplete), intro.ts welcome, README.md: documented per the standard checklist.
  - package.json: 2.1.8 → 2.1.9 to match release-v2.1.9 branch.

Tests: 327 passing (+13 new for trust):
  - missing event, 404, null/malformed json all handled gracefully
  - --market drills into one row; unknown ticker → MARKET_NOT_IN_SCORECARD
  - case-insensitive ticker matching
  - --verbose propagates to detail
  - table view contains rollup + both markets + legend + is_primary mark
  - table sorted by liquidity_quality desc
  - detail view shows score labels, top 3 drivers, risk-metric annotation, "as of report time" on point_in_time
  - --verbose surfaces evidence + confidence + freshness

Typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/trust` command to view Trader Trust scorecards for events
  * Use `--market <ticker>` to filter results for a specific market
  * Use `--verbose` to display evidence and confidence metrics

* **Documentation**
  * Help system and README updated with trust command usage

* **Chores**
  * Version bumped to 2.1.9

<!-- end of auto-generated comment: release notes by coderabbit.ai -->