### PR TITLE
feat(report): add `report <ticker>` for full Octagon markdown reports…

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Type help for commands, or just ask a question.
 | `catalysts upcoming --days N` | Markets closing in the next N days, grouped by week |
 | `trust <event_ticker>` | Trader Trust scorecard — per-market integrity scores (table view) |
 | `trust <event> --market <market>` | Single-market Trader Trust detail card (use `--verbose` for evidence) |
+| `report <ticker>` | Full Octagon markdown report for an event (accepts event/market/series/URL). `--refresh` forces a fresh pull. |
 | `themes` (registry) | Editorial narrative buckets — list/show/import/create/delete/add-series |
 | `themes report` | 25-theme dashboard with SEO + liquidity |
 | `themes audit` | Flag dead themes (high SEO + zero volume) |

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Type help for commands, or just ask a question.
 | Flag | Description |
 |------|-------------|
 | `--json` | JSON output for scripts and agents |
-| `--refresh` | Force fresh Octagon report (analyze) |
+| `--refresh` | Force fresh Octagon report (analyze, report) |
 | `--performance` | Include win rate, Sharpe, Brier scores (portfolio) |
 | `--dry-run` | Scan without persisting edges (watch) |
 | `--verbose` | Verbose output |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kalshi-trading-bot-cli",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Kalshi Trading Bot CLI - AI-powered prediction market terminal.",
   "license": "MIT",
   "author": "Octagon AI, Inc.",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -361,6 +361,7 @@ export async function runCli(options?: { forceSetup?: boolean }) {
       { value: 'basket', label: 'basket', description: 'Build / backtest / size baskets' },
       { value: 'events', label: 'events', description: 'Octagon events (event ↔ outcome ladder)' },
       { value: 'trust', label: 'trust', description: 'Trader Trust scorecard (per-market integrity scores)' },
+      { value: 'report', label: 'report', description: 'Full Octagon markdown report for an event' },
       { value: 'series', label: 'series', description: 'Series rollup / NAV' },
       { value: 'catalysts', label: 'catalysts', description: 'Upcoming market closes by week' },
       { value: 'themes', label: 'themes', description: 'Editorial narrative registry + dashboard' },
@@ -432,6 +433,7 @@ export async function runCli(options?: { forceSetup?: boolean }) {
     { name: 'correlate', description: 'Pairwise correlation matrix (2-100 tickers)', getArgumentCompletions: usageHint('<ticker1> <ticker2> [...] [--window-days N]', 'e.g. KXA KXB KXC --window-days 90') },
     { name: 'events', description: 'Octagon events — outcome ladder per event', getArgumentCompletions: usageHint('<event_ticker> | --category Politics | --min-volume 10000', 'e.g. KXFEDCHAIRNOM-29 to drill in') },
     { name: 'trust', description: 'Trader Trust scorecard (per-market integrity scores)', getArgumentCompletions: usageHint('<event_ticker> [--market <market_ticker>] [--verbose]', 'e.g. KXMENWORLDCUP-26 --market KXMENWORLDCUP-26-FR') },
+    { name: 'report', description: 'Print the full Octagon markdown report for an event', getArgumentCompletions: usageHint('<event_ticker | market_ticker | series_ticker | kalshi_url> [--refresh]', 'e.g. KXAAPLCEOCHANGE --refresh') },
     { name: 'series', description: 'Kalshi series rollup (24h vol, market count)', getArgumentCompletions: (typed: string): AutocompleteItem[] | null => {
       const opts = [
         { value: '<series_ticker>', label: '<series_ticker>', description: 'Drill into one series (e.g. KXBTCD)' },

--- a/src/commands/__tests__/report.test.ts
+++ b/src/commands/__tests__/report.test.ts
@@ -1,0 +1,200 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import type { ParsedArgs } from '../parse-args.js';
+import { handleReport, formatReportHuman } from '../report.js';
+
+function makeArgs(o: Partial<ParsedArgs>): ParsedArgs {
+  return {
+    subcommand: 'report',
+    positionalArgs: [],
+    json: false,
+    live: false, refresh: false, report: false, dryRun: false, verbose: false,
+    performance: false, resolved: false, unresolved: false,
+    behavioral: false, ranked: false, showCluster: false, activeOnly: false,
+    cells: false, autoProbs: false,
+    parseErrors: [],
+    ...o,
+  };
+}
+
+type FetchHandler = (url: string, init?: RequestInit) => Response | Promise<Response>;
+function installFetchMock(handler: FetchHandler): void {
+  globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+    return handler(s, init);
+  }) as unknown as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+// Other suites in the project unset KALSHI_PRIVATE_KEY in their afterEach
+// (see hardening.test.ts). Some report paths flow into the Octagon invoker,
+// which signs Kalshi requests — so the report suite must restore credentials
+// in its own beforeEach to stay order-independent.
+const TEST_PRIVATE_KEY = [
+  '-----BEGIN PRIVATE KEY-----',
+  'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCRFVyyjP3KGX63',
+  '0/qa6kWsCdNJTbKMBaqTaYzCVKYWr3fA4UcA3Wx9+mXwYQ0+jULQP9Y1qWBpWTmb',
+  'vnZaejJaywFK6LESStChcXuqN8uBcF13+CfwxVdbTboAbaHaNsOjHwl6JuYW0Nz+',
+  'jOQmN0v/nT/SSq8BOLN7S408VW5yR3sC+W9oJ0qb6gVNJTHazxuEvCjz8k5w+a+D',
+  'otAVUg/Y9WVIJqKhIhvQnD2pAN5J20RI4YXfz31GTaKzwMmg/ByoGrtkeJw4StFW',
+  'HSVfo2/j9H1EdMTEHyjLyGyXjfiQOTSp/gK0BjaMHGzdltFueCOss8RoQjv2n+2m',
+  'OL+aNv7tAgMBAAECggEAEkm0DpmxH/mIvJlO3JotQBtY88OEfxvzvXMvmAtdiDyE',
+  'Bt8euSAwHc0jbmJ9beYWhvOVB9ya14y0s0oV1x/SGxm9xvh/4YNmuwL4CKPR1jYY',
+  'wheYyUPG2C57BLTNExmWHYi7BBfFJxka0kdmNt7/iHAE7HgXiTrhfOgwHGvUaTki',
+  'zDuq/I2rUaG4bDHA8EK19DdFCb2+TuqGYnc7vkMgwz2NajGZNXqOWCJabMVLeQR2',
+  'niVRsFo2kY1uXB6Oy+nEixVnTxWRQhT//UWbLr4iJZnlJGpwPGKZZHhNADbx+w+0',
+  'ig3iqVnYY11s7cceGTV7C9fGr+H9pERtTp3e1cPmLQKBgQDIP2WoJVz12wUd4ANM',
+  'Jz1xpxsYg3txnTST01OidaWxeaDHg/mjzsdKPdMa7eBREJYy4HUllLZrvI9KWp/4',
+  'wLCB0aCuytGf6Z2u/bOoTs87HMf13PzC0ksD1Ri9wEECN5NlVnL9NNcnpPE+6gGY',
+  '2OzJtzfdr5JwPC5U12IDQVEAWwKBgQC5eiZhZKwHHeQQzJqgURDd3hZJpQdFDcFp',
+  'QSH1dNHNdNutTLZ7JakSQcoz9P4Fuu4AEPGCi94xH4NoIq7fPY4ABX0a3vp9guJ+',
+  'txChCHusjwVGGcraGSiognyxBnewpt+lzv1xDWBmmGaDqSVayS9eQaEiMypHbaah',
+  '2vsiQBWgVwKBgC/EN6qZZwhae2j5869puNVwiB0b2Als94q/oTaim6ivG7Qb/iOe',
+  'ApnqD35f+d88dqeiNS+GvtEKRJ/26Cv9Qt1ktNCdHs3ney6v4/gk/HfcULKMSVrr',
+  'sOs0HNe+kYNG4IkOyxUtUplpVgas6T6dmDYx10ixRdwx7tdcHUwre3f7AoGARkWP',
+  'UQsRWkjq5ap/Uwojt8uy6ggKbxE9HCG/Of4elxcVO916rcGhAvfGIlVKAOXH0mKY',
+  '/fr8HeRwpv2s/4uUx1FNCuc8RF1YbuXw+PH72W7+cobHIkax7tYxY+itZFJ1HZ8E',
+  'ytZklbpb7LojGvhqZ+25nPmBpTpYDa6nw1xAVVUCgYEAqKcg/QSJIcj+qODjtZZ8',
+  'aCqNvagzw74Hruh9jmd3tLvqpzKN72GqdtuzRoGi2BzmjUkrTXhEugf4/AaxfLMy',
+  'yk6j0nzHRSVi1GUzx/P/q6gsR8bEvhhBSZEwQxcQDL+1Toamz1nmFXLZo0w3hi6q',
+  'wZ0ONbXRO/Hcg1MzeK10biQ=',
+  '-----END PRIVATE KEY-----',
+].join('\n');
+
+describe('handleReport', () => {
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    process.env.OCTAGON_API_KEY = 'sk_test';
+    process.env.KALSHI_API_KEY = 'test-key';
+    process.env.KALSHI_PRIVATE_KEY = TEST_PRIVATE_KEY;
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.OCTAGON_API_KEY;
+    delete process.env.KALSHI_API_KEY;
+    delete process.env.KALSHI_PRIVATE_KEY;
+  });
+
+  test('missing ticker → MISSING_TICKER', async () => {
+    installFetchMock(() => jsonResponse({}));
+    const resp = await handleReport(makeArgs({ positionalArgs: [] }));
+    expect(resp.ok).toBe(false);
+    if (resp.ok) return;
+    expect(resp.error?.code).toBe('MISSING_TICKER');
+  });
+
+  test('Octagon event lookup 404 + Kalshi resolver failure → EVENT_NOT_FOUND', async () => {
+    installFetchMock((url) => {
+      // Octagon events endpoint 404; Kalshi /markets, /events, series all 404
+      return new Response(JSON.stringify({ error: { code: 'not_found' } }), { status: 404 });
+    });
+    const resp = await handleReport(makeArgs({ positionalArgs: ['KX-BOGUS'] }));
+    expect(resp.ok).toBe(false);
+    if (resp.ok) return;
+    expect(resp.error?.code).toBe('EVENT_NOT_FOUND');
+  });
+
+  test('normalizes URL + lowercase before lookup', async () => {
+    let eventLookupUrl = '';
+    installFetchMock((url) => {
+      if (url.includes('/v1/prediction-markets/events/')) {
+        // Capture the FIRST lookup (the user-input → event), not the later
+        // re-lookup with the canonical event_ticker.
+        if (!eventLookupUrl) eventLookupUrl = url;
+        return jsonResponse({
+          event_ticker: 'KXMEASLES-26',
+          name: 'Measles cases in 2026',
+        });
+      }
+      return jsonResponse({});
+    });
+    // Call but ignore the eventual "no report body" branch — we only
+    // care that the input got normalized before being sent to Octagon.
+    await handleReport(makeArgs({
+      positionalArgs: ['https://kalshi.com/markets/kxmeasles/measles-cases/kxmeasles-26'],
+    }));
+    expect(eventLookupUrl).toContain('/KXMEASLES-26');
+  });
+
+  test('uses outcome_probabilities market_ticker for the Octagon invoker URL', async () => {
+    // Verifies the bug fix: when fetchOctagonEventDirect returns an event_ticker
+    // that isn't itself a valid Kalshi /markets/{ticker} (e.g. series-style
+    // event tickers like KXAAPLCEOCHANGE), the report command must pick a real
+    // market_ticker from outcome_probabilities before hitting the invoker.
+    const kalshiMarketCalls: string[] = [];
+    installFetchMock((url) => {
+      if (url.includes('/v1/prediction-markets/events/')) {
+        return jsonResponse({
+          event_ticker: 'KXAAPLCEOCHANGE',
+          name: 'When will Tim Cook leave Apple?',
+          outcome_probabilities: [
+            { market_ticker: 'KXAAPLCEOCHANGE-T2027', model_probability: 30, market_probability: 25 },
+          ],
+        });
+      }
+      if (url.match(/\/trade-api\/v2\/markets\/[^?/]+$/)) {
+        kalshiMarketCalls.push(url);
+        return jsonResponse({ market: { ticker: 'KXAAPLCEOCHANGE-T2027', event_ticker: 'KXAAPLCEOCHANGE' } });
+      }
+      if (url.includes('/trade-api/v2/events/')) {
+        return jsonResponse({ event: { series_ticker: 'KXAAPLCEOCHANGE' } });
+      }
+      if (url.includes('/trade-api/v2/series/')) {
+        return jsonResponse({ series: { title: 'Apple CEO Change' } });
+      }
+      if (url.includes('/responses')) {
+        return jsonResponse({ output_text: '# Report body' });
+      }
+      return jsonResponse({});
+    });
+    const resp = await handleReport(makeArgs({ positionalArgs: ['KXAAPLCEOCHANGE'] }));
+    expect(resp.ok).toBe(true);
+    // The first Kalshi /markets/{ticker} call from the invoker must use the
+    // market_ticker, NOT the bare event_ticker (which would 404).
+    expect(kalshiMarketCalls.length).toBeGreaterThan(0);
+    expect(kalshiMarketCalls[0]).toContain('/markets/KXAAPLCEOCHANGE-T2027');
+    expect(kalshiMarketCalls[0]).not.toMatch(/\/markets\/KXAAPLCEOCHANGE$/);
+  });
+});
+
+describe('formatReportHuman', () => {
+  test('renders markdown body with header + footer metadata', () => {
+    const out = formatReportHuman({
+      ticker: 'KXAAPLCEOCHANGE-26',
+      requestedTicker: 'KXAAPLCEOCHANGE',
+      title: 'When will Tim Cook leave Apple?',
+      source: 'cache',
+      rawReport: '# Tim Cook tenure\n\nNo signs of imminent departure.',
+      refreshedAt: '2026-06-25 12:00 UTC',
+      modelRunAt: '2026-06-25 10:30 UTC',
+      reportAge: '5m ago',
+    });
+    expect(out).toContain('KXAAPLCEOCHANGE-26');
+    expect(out).toContain('Tim Cook tenure');
+    expect(out).toContain('No signs of imminent departure');
+    expect(out).toContain('When will Tim Cook leave Apple?');
+    expect(out).toContain('Cache refreshed at:    2026-06-25 12:00 UTC (5m ago)');
+    expect(out).toContain('Report body updated at: 2026-06-25 10:30 UTC');
+    expect(out).toMatch(/cached.*--refresh/);
+  });
+
+  test('omits metadata lines that are null', () => {
+    const out = formatReportHuman({
+      ticker: 'KX-A',
+      requestedTicker: 'KX-A',
+      title: null,
+      source: 'fresh',
+      rawReport: '# Body',
+      refreshedAt: null,
+      modelRunAt: null,
+      reportAge: null,
+    });
+    expect(out).not.toContain('Title:');
+    expect(out).not.toContain('Cache refreshed at:');
+    expect(out).not.toContain('Report body updated at:');
+    expect(out).toContain('freshly generated');
+  });
+});

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -13,6 +13,7 @@ import { openPosition, closePosition, getOpenPositions } from '../db/positions.j
 import { logTrade } from '../db/trades.js';
 import { formatRawReport, parseMarketProb, parsePriceField } from '../controllers/browse.js';
 import type { PriceDriver, Catalyst, Source } from '../scan/types.js';
+import { formatAge } from '../utils/time.js';
 import { kellySize, getVolume24h } from '../risk/kelly.js';
 import type { KellyResult } from '../risk/kelly.js';
 import { riskGate } from '../risk/gate.js';
@@ -97,15 +98,6 @@ function deriveLiquidityGrade(market: KalshiMarket): string {
   return 'Poor';
 }
 
-function formatAge(epochSeconds: number): string {
-  const ageMs = Date.now() - epochSeconds * 1000;
-  const mins = Math.floor(ageMs / 60000);
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
 
 function getVolume(m: KalshiMarket): number {
   if (m.volume_fp != null) {

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -35,6 +35,7 @@ import { searchKalshiMarkets, getMarketsWithEdge } from '../scan/octagon-kalshi-
 import { formatMarketSearchHuman, formatMarketsWithEdgeHuman } from './search-remote.js';
 import { handleEvents, formatEventsHuman } from './events.js';
 import { handleTrust, formatTrustHuman } from './trust.js';
+import { handleReport, formatReportHuman } from './report.js';
 import { handleSeries, formatSeriesHuman } from './series.js';
 import { handleEditorialThemes, formatEditorialThemesHuman } from './editorial-themes.js';
 import { handleCatalysts, formatCatalystsHuman } from './catalysts.js';
@@ -495,6 +496,20 @@ export async function dispatch(args: ParsedArgs): Promise<void> {
         console.log(formatSeriesHuman(resp.data));
       } else {
         console.error(resp.error?.message ?? 'series failed');
+      }
+      process.exit(resp.ok ? ExitCode.SUCCESS : ExitCode.USER_ERROR);
+      return;
+    }
+
+    // ─── report (full Octagon markdown report) ─────────────────────────
+    if (resolved.canonical === 'report') {
+      const resp = await handleReport(args);
+      if (json) {
+        console.log(JSON.stringify(resp));
+      } else if (resp.ok) {
+        console.log(formatReportHuman(resp.data));
+      } else {
+        console.error(resp.error?.message ?? 'report failed');
       }
       process.exit(resp.ok ? ExitCode.SUCCESS : ExitCode.USER_ERROR);
       return;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -249,6 +249,27 @@ Flags:
 
 Output ranks pairs ascending by correlation — most-uncorrelated first.`,
 
+    report: `**${p}report** — Print the full Octagon markdown report for an event
+
+${p}report <event_ticker>           Cached report body (most recent)
+${p}report <market_ticker>          Resolves to the parent event automatically
+${p}report <series_ticker>          Resolves to the latest event in the series
+${p}report <kalshi_url>             Accepts a full kalshi.com URL too
+${p}report <ticker> --refresh       Force a fresh pull from Octagon (costs 3 credits)
+
+The full deep-research markdown body — same content the OctagonAI web app shows.
+Lookup is more lenient than \`analyze\`: tries Octagon's event endpoint first
+before falling back to the Kalshi resolver chain, so series tickers and
+events without open Kalshi markets still work.
+
+Flags:
+  --refresh    Force a fresh report instead of returning the cached one
+  --json       JSON envelope output (rawReport carries the markdown)
+
+Output footer always shows: source (cache | fresh | cache-miss), local cache
+fetch timestamp + age, and the upstream Octagon analysis_last_updated when
+available — so you can decide whether to --refresh.`,
+
     trust: `**${p}trust** — Trader Trust scorecard (market-integrity metrics)
 
 ${p}trust <event_ticker>                       Table across all markets in the event
@@ -458,6 +479,7 @@ Discovery:
   catalysts upcoming --days 30  Markets closing soon, grouped by week
   trust <event_ticker>          Trader Trust scorecard (table across markets)
   trust <event> --market <mkt>  Single-market trust detail card
+  report <event_ticker>         Full Octagon markdown report (use --refresh for fresh pull)
   watch <ticker>                Live price/orderbook feed
   watch --theme <theme>         Continuous theme scan (Ctrl+C to stop)
   watch --refresh               Force index rebuild before watching
@@ -537,6 +559,7 @@ Discovery:
   /catalysts upcoming --days 30  Markets closing soon, grouped by week
   /trust <event_ticker>          Trader Trust scorecard (table across markets)
   /trust <event> --market <mkt>  Single-market trust detail card
+  /report <event_ticker>         Full Octagon markdown report (use --refresh for fresh pull)
   /watch <ticker>                Live price/orderbook feed
   /watch --theme <theme>         Continuous theme scan (Esc to stop)
   /watch --refresh               Force index rebuild before watching

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -263,12 +263,14 @@ before falling back to the Kalshi resolver chain, so series tickers and
 events without open Kalshi markets still work.
 
 Flags:
-  --refresh    Force a fresh report instead of returning the cached one
-  --json       JSON envelope output (rawReport carries the markdown)
+  --refresh    Force a fresh report instead of returning the cached one${ctx === 'cli' ? `
+  --json       JSON envelope output (rawReport carries the markdown)` : ''}
 
-Output footer always shows: source (cache | fresh | cache-miss), local cache
-fetch timestamp + age, and the upstream Octagon analysis_last_updated when
-available — so you can decide whether to --refresh.`,
+When a report body is found, the output footer shows: source (cache | fresh),
+local cache fetch timestamp + age, and the upstream Octagon
+analysis_last_updated when available — so you can decide whether to --refresh.
+Error paths (missing ticker, event not found, no report body yet) print just
+the error message instead.`,
 
     trust: `**${p}trust** — Trader Trust scorecard (market-integrity metrics)
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -38,6 +38,7 @@ import { handleCorrelate, formatCorrelationHuman } from './correlate.js';
 import { handleBasket, formatBasketHuman } from './basket.js';
 import { handleEvents, formatEventsHuman } from './events.js';
 import { handleTrust, formatTrustHuman } from './trust.js';
+import { handleReport, formatReportHuman } from './report.js';
 import { handleSeries, formatSeriesHuman } from './series.js';
 import { handleEditorialThemes, formatEditorialThemesHuman } from './editorial-themes.js';
 import { handleCatalysts, formatCatalystsHuman } from './catalysts.js';
@@ -251,6 +252,16 @@ export async function handleSlashCommand(input: string): Promise<CommandResult |
         asyncFollowUp: async () => {
           const resp = await handleTrust(parsed);
           return resp.ok ? formatTrustHuman(resp.data) : (resp.error?.message ?? 'trust failed');
+        },
+      };
+    }
+    case 'report': {
+      const parsed = parseArgs(['report', ...args]);
+      return {
+        output: parsed.refresh ? 'Refreshing Octagon report...' : 'Fetching Octagon report...',
+        asyncFollowUp: async () => {
+          const resp = await handleReport(parsed);
+          return resp.ok ? formatReportHuman(resp.data) : (resp.error?.message ?? 'report failed');
         },
       };
     }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -257,6 +257,12 @@ export async function handleSlashCommand(input: string): Promise<CommandResult |
     }
     case 'report': {
       const parsed = parseArgs(['report', ...args]);
+      // Reject unknown / malformed flags before kicking off the Octagon call
+      // (network round-trip + 3 credits on --refresh). dispatch.ts does the
+      // same for the CLI path; slash command path needs its own guard.
+      if (parsed.parseErrors.length > 0) {
+        return { output: parsed.parseErrors.join('; ') };
+      }
       return {
         output: parsed.refresh ? 'Refreshing Octagon report...' : 'Fetching Octagon report...',
         asyncFollowUp: async () => {

--- a/src/commands/parse-args.ts
+++ b/src/commands/parse-args.ts
@@ -13,6 +13,8 @@ const SUBCOMMANDS = [
   'events', 'series', 'catalysts',
   // Trader Trust scorecard
   'trust',
+  // Full markdown report viewer
+  'report',
 ] as const;
 
 export type Subcommand = (typeof SUBCOMMANDS)[number];

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -1,0 +1,260 @@
+/**
+ * `report <ticker>` — print the full Octagon markdown report for an event.
+ *
+ * Focused command: no Kelly, no risk gate, no trade prompts — just the raw
+ * markdown body Octagon generates for the event. Common use case: a user
+ * wants to see the deep-research report so they can decide whether to
+ * --refresh it.
+ *
+ * Input handling is more forgiving than `analyze`:
+ *   1. Normalize URL / case via normalizeKalshiInput
+ *   2. Try Octagon's events endpoint directly first (works for any covered
+ *      event regardless of Kalshi market liquidity / trade state)
+ *   3. Fall back to resolveMarket for series tickers and other forms that
+ *      need the Kalshi /events lookup chain
+ *
+ * Step 2 fixes the user-reported case where `analyze KXAAPLCEOCHANGE` blew
+ * up at the Kalshi resolver but Octagon clearly has the event.
+ */
+import { wrapSuccess, wrapError } from './json.js';
+import type { CLIResponse } from './json.js';
+import type { ParsedArgs } from './parse-args.js';
+import { getDb } from '../db/index.js';
+import { auditTrail } from '../audit/index.js';
+import { OctagonClient } from '../scan/octagon-client.js';
+import { createOctagonInvoker } from '../scan/invoker.js';
+import { fetchOctagonEventDirect } from '../scan/octagon-events-api.js';
+import type { OctagonEventEntry } from '../scan/octagon-events-api.js';
+import { normalizeKalshiInput, resolveMarket } from './analyze.js';
+import { callKalshiApi } from '../tools/kalshi/api.js';
+import { formatRawReport } from '../controllers/browse.js';
+import { theme } from '../theme.js';
+
+/**
+ * Pick a market_ticker we can hand to the Octagon invoker. The invoker calls
+ * Kalshi `/markets/{ticker}` to build the canonical kalshi.com URL — it needs
+ * a MARKET ticker (e.g. `KXAAPLCEOCHANGE-T2027`), not an event ticker.
+ *
+ * Three sources, in preference order:
+ *   1. Octagon's `outcome_probabilities[0].market_ticker` (always present for
+ *      events with a deep-research report).
+ *   2. Kalshi `/events/{event_ticker}?with_nested_markets=true`, picking any
+ *      market (open if available, else first listed — historical reports for
+ *      closed events still need a real market_ticker to build the URL).
+ *   3. The event_ticker itself, as a last-resort guess (a few one-market
+ *      events use it as their market ticker too).
+ */
+async function pickMarketTickerForInvoker(eventTicker: string, ev: OctagonEventEntry | null): Promise<string> {
+  const outcomes = ev?.outcome_probabilities ?? [];
+  if (outcomes.length > 0 && outcomes[0]?.market_ticker) return outcomes[0].market_ticker;
+
+  try {
+    const res = await callKalshiApi('GET', `/events/${eventTicker}`, {
+      params: { with_nested_markets: true },
+    });
+    const event = ((res as Record<string, unknown>).event ?? res) as Record<string, unknown>;
+    const markets = (event.markets as Array<Record<string, unknown>> | undefined) ?? [];
+    if (markets.length > 0) {
+      const open = markets.find((m) => m.status === 'open' || m.status === 'active');
+      const pick = (open ?? markets[0]).ticker as string | undefined;
+      if (pick) return pick;
+    }
+  } catch {
+    // Kalshi auth missing / event missing / network — fall through to the
+    // event_ticker guess. The invoker will produce a clearer downstream
+    // error if the guess turns out to be wrong.
+  }
+
+  return eventTicker;
+}
+
+/**
+ * Octagon's cache-variant endpoint returns a small JSON envelope when there is
+ * no cached report — typically `{"versions":[]}` or `{"cache_miss":true}`.
+ * For the report command, the raw markdown body is the value; OctagonClient's
+ * inferential `cacheMiss` flag (which triggers on "no model_prob extracted")
+ * mislabels legitimate report bodies that lack a parseable probability.
+ * Detect the actual cache-miss envelope shape instead.
+ */
+function isOctagonCacheMissEnvelope(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) return true;
+  if (!trimmed.startsWith('{')) return false;
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    if (parsed.cache_miss === true || parsed.cacheMiss === true) return true;
+    if (Array.isArray(parsed.versions) && parsed.versions.length === 0) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/** Format epoch seconds as a relative-age string. Mirrors analyze.ts:formatAge. */
+function formatAge(epochSeconds: number): string {
+  const ageMs = Date.now() - epochSeconds * 1000;
+  const mins = Math.floor(ageMs / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export interface ReportData {
+  /** The ticker we ended up using to fetch the report (event_ticker). */
+  ticker: string;
+  /** What the user typed (before normalization). */
+  requestedTicker: string;
+  /** Octagon's event name / title, when available. */
+  title: string | null;
+  /** Source: 'cache' (served from local cache), 'fresh' (just pulled from Octagon), 'cache-miss' (couldn't get either). */
+  source: 'cache' | 'fresh' | 'cache-miss';
+  /** Raw markdown report body. Empty string when source = 'cache-miss'. */
+  rawReport: string;
+  /** Local cache timestamp (UTC), if we have one. */
+  refreshedAt: string | null;
+  /** Octagon upstream model-run timestamp, if known. */
+  modelRunAt: string | null;
+  /** Human-readable age string like "12m ago". */
+  reportAge: string | null;
+}
+
+export async function handleReport(args: ParsedArgs): Promise<CLIResponse<ReportData>> {
+  const rawInput = args.positionalArgs[0];
+  if (!rawInput) {
+    return wrapError(
+      'report',
+      'MISSING_TICKER',
+      'Usage: report <event_ticker | market_ticker | series_ticker | kalshi_url> [--refresh]',
+    );
+  }
+  const input = normalizeKalshiInput(rawInput);
+  const db = getDb();
+
+  // Step 1: try input as an event ticker directly via Octagon. This works
+  // for events where Kalshi's resolver chain fails (e.g. the series has
+  // no open markets right now, or the event ticker form doesn't match
+  // Kalshi's expected shape).
+  let eventTicker: string | null = null;
+  let title: string | null = null;
+  let octagonEvent: OctagonEventEntry | null = null;
+  let analysisLastUpdated: string | null = null;
+  try {
+    octagonEvent = await fetchOctagonEventDirect(input);
+    if (octagonEvent) {
+      eventTicker = octagonEvent.event_ticker;
+      title = octagonEvent.name ?? null;
+      analysisLastUpdated = octagonEvent.analysis_last_updated ?? null;
+    }
+  } catch {
+    // Octagon failure shouldn't block — we'll try the Kalshi path next.
+  }
+
+  // Step 2: fall back to Kalshi's resolver chain (market → event → series).
+  if (!eventTicker) {
+    try {
+      const market = await resolveMarket(input);
+      eventTicker = market.event_ticker;
+      title = market.title ?? null;
+      // Take one more shot at the events endpoint with the resolved
+      // event ticker — gets us a better title and the upstream timestamp.
+      try {
+        octagonEvent = await fetchOctagonEventDirect(eventTicker);
+        if (octagonEvent?.name) title = octagonEvent.name;
+        if (octagonEvent?.analysis_last_updated) analysisLastUpdated = octagonEvent.analysis_last_updated;
+      } catch { /* ignore */ }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return wrapError(
+        'report',
+        'EVENT_NOT_FOUND',
+        `Could not find an event for "${rawInput}" (normalized: "${input}"). ${msg}`,
+      );
+    }
+  }
+
+  // Step 3: fetch the report. The invoker expects a MARKET ticker (not an
+  // event ticker) — it calls Kalshi `/markets/{ticker}` to build the
+  // canonical kalshi.com URL Octagon needs. Pick one before invoking.
+  const marketTickerForInvoker = await pickMarketTickerForInvoker(eventTicker, octagonEvent);
+
+  const invoker = createOctagonInvoker();
+  const client = new OctagonClient(invoker, db, auditTrail);
+
+  let rawReport = '';
+  let source: ReportData['source'] = 'cache-miss';
+  let refreshedAtEpoch: number | null = null;
+
+  if (!args.refresh) {
+    const prefetched = client.tryFromPrefetch(marketTickerForInvoker, eventTicker);
+    if (prefetched?.rawResponse && !isOctagonCacheMissEnvelope(prefetched.rawResponse)) {
+      rawReport = prefetched.rawResponse;
+      source = 'cache';
+      refreshedAtEpoch = prefetched.fetchedAt;
+    }
+  }
+
+  if (!rawReport) {
+    try {
+      const variant = args.refresh ? 'refresh' : 'cache';
+      const fresh = await client.fetchReport(marketTickerForInvoker, eventTicker, variant);
+      if (fresh.rawResponse && !isOctagonCacheMissEnvelope(fresh.rawResponse)) {
+        rawReport = fresh.rawResponse;
+        source = args.refresh ? 'fresh' : 'cache';
+        refreshedAtEpoch = fresh.fetchedAt;
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return wrapError('report', 'OCTAGON_ERROR', msg);
+    }
+  }
+
+  if (!rawReport) {
+    return wrapError(
+      'report',
+      'NO_REPORT',
+      `Octagon has no report body for ${eventTicker} yet. The event exists but no deep-research report has been generated. Try \`report ${eventTicker} --refresh\` to force one.`,
+    );
+  }
+
+  const refreshedAt = refreshedAtEpoch
+    ? new Date(refreshedAtEpoch * 1000).toISOString().replace('T', ' ').slice(0, 16) + ' UTC'
+    : null;
+  const reportAge = refreshedAtEpoch ? formatAge(refreshedAtEpoch) : null;
+  const modelRunAt = analysisLastUpdated
+    ? analysisLastUpdated.replace('T', ' ').slice(0, 16) + ' UTC'
+    : null;
+
+  return wrapSuccess('report', {
+    ticker: eventTicker,
+    requestedTicker: rawInput,
+    title,
+    source,
+    rawReport,
+    refreshedAt,
+    modelRunAt,
+    reportAge,
+  });
+}
+
+export function formatReportHuman(data: ReportData): string {
+  const lines: string[] = [];
+  lines.push(formatRawReport(data.rawReport, data.ticker));
+  lines.push('');
+  if (data.title) lines.push(theme.muted(`  Title: ${data.title}`));
+  if (data.refreshedAt) {
+    const age = data.reportAge ? ` (${data.reportAge})` : '';
+    lines.push(theme.muted(`  Cache refreshed at:    ${data.refreshedAt}${age}`));
+  }
+  if (data.modelRunAt) {
+    lines.push(theme.muted(`  Report body updated at: ${data.modelRunAt}   (upstream Octagon analysis_last_updated)`));
+  }
+  if (data.source === 'cache') {
+    lines.push(theme.muted(`  Source: cached. Run \`report ${data.ticker} --refresh\` to force a fresh pull (costs 3 Octagon credits).`));
+  } else if (data.source === 'fresh') {
+    lines.push(theme.muted(`  Source: freshly generated.`));
+  }
+  return lines.join('\n');
+}

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -29,6 +29,7 @@ import { normalizeKalshiInput, resolveMarket } from './analyze.js';
 import { callKalshiApi } from '../tools/kalshi/api.js';
 import { formatRawReport } from '../controllers/browse.js';
 import { theme } from '../theme.js';
+import { formatAge } from '../utils/time.js';
 
 /**
  * Pick a market_ticker we can hand to the Octagon invoker. The invoker calls
@@ -88,18 +89,6 @@ function isOctagonCacheMissEnvelope(raw: string): boolean {
   } catch {
     return false;
   }
-}
-
-/** Format epoch seconds as a relative-age string. Mirrors analyze.ts:formatAge. */
-function formatAge(epochSeconds: number): string {
-  const ageMs = Date.now() - epochSeconds * 1000;
-  const mins = Math.floor(ageMs / 60_000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }
 
 export interface ReportData {

--- a/src/components/intro.ts
+++ b/src/components/intro.ts
@@ -73,6 +73,7 @@ export class IntroComponent extends Container {
     this.addChild(new Text(cmd('/peers') + '<ticker>  Markets in the same cluster', 0, 0));
     this.addChild(new Text(cmd('/events') + '[ticker]  Octagon events + outcome ladder', 0, 0));
     this.addChild(new Text(cmd('/trust') + '<event_ticker>  Trader Trust scorecard (per-market integrity)', 0, 0));
+    this.addChild(new Text(cmd('/report') + '<event_ticker>  Full Octagon markdown report (--refresh for fresh)', 0, 0));
     this.addChild(new Text(cmd('/series') + '[ticker]  Series rollup; /series candles <SERIES> for NAV', 0, 0));
     this.addChild(new Text(cmd('/themes') + 'list|show|report|audit|overlap  Editorial narrative registry', 0, 0));
     this.addChild(new Text(cmd('/catalysts') + 'upcoming --days N  Markets closing soon, grouped by week', 0, 0));

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,18 @@
+/**
+ * Format an epoch-seconds timestamp as a relative-age string
+ * (e.g. "just now", "12m ago", "3h ago", "2d ago").
+ *
+ * Shared between commands that surface cache/report freshness — keep the
+ * thresholds in one place so the same fetch_at renders identically across
+ * `analyze`, `report`, etc.
+ */
+export function formatAge(epochSeconds: number): string {
+  const ageMs = Date.now() - epochSeconds * 1000;
+  const mins = Math.floor(ageMs / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}


### PR DESCRIPTION
…; bump 2.1.10

The existing /analyze and /search commands only surface summaries — users wanting to see (and decide whether to refresh) the deep-research markdown body had no path. The Slack thread that prompted this: "I tried this one. It does give me a summary but not the full markdown: view report KXAAPLCEOCHANGE."

Adds a focused command that prints the raw markdown report with --refresh support. Two resolution paths so the user-reported tickers work end-to-end:

  1. Try Octagon's /v1/prediction-markets/events/{ticker} directly — handles closed/series-style events Kalshi's resolver chain rejects.
  2. Fall back to resolveMarket (market → event → series) for live markets where Octagon's events endpoint 404s.

Key fix: the Octagon invoker calls Kalshi /markets/{ticker} to build the canonical URL — it needs a MARKET ticker, not an event ticker. Without this, KXAAPLCEOCHANGE was passed through and 404'd at Kalshi with "Market ticker 'KXAAPLCEOCHANGE' not found." New pickMarketTickerForInvoker prefers Octagon's outcome_probabilities[0] .market_ticker, then Kalshi /events nested-markets, then event_ticker as a last-resort guess.

isOctagonCacheMissEnvelope detects the {"versions":[]} / {cache_miss} JSON envelopes Octagon returns on real cache misses, so the report command surfaces actual report bodies even when no model probability was parseable (analyze's inferential cacheMiss flag is too strict here. EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `report` command to generate full Octagon markdown reports from a ticker or supported URL, including slash-command support and argument autocompletion.
  * Added `--refresh` to force fresh retrieval, with output available in human-readable markdown and JSON modes.
  * Updated help and intro screens to document the new command and flags.

* **Bug Fixes**
  * Improved report error handling for missing input, missing events, and missing report bodies.
  * Enhanced cache-miss detection and ensured the correct market ticker is used during downstream fetching.

* **Tests**
  * Added Bun test coverage for report retrieval and human markdown formatting.

* **Refactor/Chores**
  * Shared relative-age formatting via a common utility; bumped package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->