### PR TITLE
fix(portfolio): use position_fp when filtering open positions

### DIFF
--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -297,7 +297,7 @@ export async function dispatch(args: ParsedArgs): Promise<void> {
         const data = await callKalshiApi('GET', '/portfolio/positions');
         const allPositions = (data.market_positions ?? data.positions ?? []) as KalshiPosition[];
         const positions = allPositions.filter((p) => {
-          const pos = parseFloat(String(p.position ?? '0'));
+          const pos = parseFloat(String(p.position_fp ?? p.position ?? '0'));
           return pos !== 0;
         });
         if (json) {


### PR DESCRIPTION
## Summary
- `portfolio positions` filtered on the legacy `position` field, which Kalshi's API no longer returns (it now sends `position_fp`)
- Every row parsed to `0` and got filtered out, so the CLI always showed "No open positions" even when the account had real open positions with real exposure
- Now checks `position_fp` first, falling back to `position`

## Test plan
- [x] Verified against a live production account with 8 real open positions (~$370 exposure) that were previously hidden by this bug
- [x] Confirmed `portfolio positions` now renders all 8 positions with correct ticker, size, P&L, and exposure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portfolio positions value calculation to use the more precise numeric value when available, with a fallback to the previous value format.
  * Continued excluding positions with a computed value of zero from the view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->